### PR TITLE
feat: submission list pages

### DIFF
--- a/forms_pro/api/submission.py
+++ b/forms_pro/api/submission.py
@@ -19,6 +19,7 @@ class UserSubmissionResponse(BaseModel):
         alias="fp_submission_status",
         default=SubmissionStatus.SUBMITTED.value,
     )
+    owner: str = Field(description="Owner of the submission")
 
     @field_validator("creation", "modified", mode="before")
     @classmethod
@@ -104,7 +105,7 @@ def get_user_submissions(form_id: str) -> list[UserSubmissionResponse]:
     submissions = frappe.get_all(
         doctype=linked_doctype,
         filters={"owner": frappe.session.user},
-        fields=["name", "creation", "modified", "fp_submission_status"],
+        fields=["name", "creation", "modified", "fp_submission_status", "owner"],
         order_by="creation",
     )
 
@@ -131,3 +132,35 @@ def get_submission(submission_doctype: str, submission_name: str) -> dict[str, A
         )
 
     return submission.as_dict()
+
+
+@frappe.whitelist()
+def get_all_submissions(form_id: str) -> list[UserSubmissionResponse]:
+    """
+    Get all submissions for a form
+
+    Args:
+        form_id: The ID of the form
+
+    Returns:
+        A list of submissions for the form
+    """
+    linked_team = frappe.db.get_value("Form", form_id, "linked_team_id")
+
+    if not frappe.has_permission(doctype="FP Team", ptype="write", doc=linked_team, user=frappe.session.user):
+        frappe.throw(
+            _("You do not have permission to read this form's submissions."),
+            frappe.PermissionError,
+        )
+
+    form: Form = frappe.get_doc("Form", form_id)
+    linked_doctype = form.linked_doctype
+
+    submissions = frappe.get_all(
+        doctype=linked_doctype,
+        fields=["name", "creation", "modified", "fp_submission_status", "owner"],
+        filters={"fp_submission_status": "Submitted"},
+        order_by="creation",
+    )
+
+    return [UserSubmissionResponse.model_validate(submission).model_dump() for submission in submissions]

--- a/forms_pro/api/submission.py
+++ b/forms_pro/api/submission.py
@@ -129,17 +129,20 @@ def get_submission_response(submission_id: str, doctype: str) -> dict[str, Any]:
     if not linked_form:
         frappe.throw(_("Submission not found."), frappe.DoesNotExistError)
 
-    linked_team_id = frappe.db.get_value("Form", linked_form, "linked_team_id")
+    form_data = frappe.db.get_value("Form", linked_form, ["linked_team_id", "linked_doctype"], as_dict=True)
+
+    if form_data.linked_doctype != doctype:
+        frappe.throw(_("Invalid doctype for this submission."), frappe.PermissionError)
 
     if not frappe.has_permission(
-        doctype="FP Team", ptype="write", doc=linked_team_id, user=frappe.session.user
+        doctype="FP Team", ptype="write", doc=form_data.linked_team_id, user=frappe.session.user
     ):
         frappe.throw(
             _("You do not have permission to read this form's submissions."),
             frappe.PermissionError,
         )
 
-    submission = frappe.get_doc(doctype, submission_id)
+    submission = frappe.get_doc(form_data.linked_doctype, submission_id)
     return submission.as_dict()
 
 

--- a/forms_pro/api/submission.py
+++ b/forms_pro/api/submission.py
@@ -181,6 +181,9 @@ def get_all_submissions(form_id: str) -> list[UserSubmissionResponse]:
     """
     linked_team = frappe.db.get_value("Form", form_id, "linked_team_id")
 
+    if not linked_team:
+        frappe.throw(_("Form not found."), frappe.DoesNotExistError)
+
     if not frappe.has_permission(doctype="FP Team", ptype="write", doc=linked_team, user=frappe.session.user):
         frappe.throw(
             _("You do not have permission to read this form's submissions."),

--- a/forms_pro/api/submission.py
+++ b/forms_pro/api/submission.py
@@ -113,9 +113,40 @@ def get_user_submissions(form_id: str) -> list[UserSubmissionResponse]:
 
 
 @frappe.whitelist()
+def get_submission_response(submission_id: str, doctype: str) -> dict[str, Any]:
+    """
+    Get a full submission response by ID.
+    This API checks if the user is the team member / the form is shared with the user.
+
+    Args:
+        submission_id: The name/ID of the submission document
+        doctype: The submission's doctype (linked_doctype of the form)
+
+    Returns:
+        The submission document as a dict
+    """
+    linked_form = frappe.db.get_value(doctype, submission_id, "fp_linked_form")
+    if not linked_form:
+        frappe.throw(_("Submission not found."), frappe.DoesNotExistError)
+
+    linked_team_id = frappe.db.get_value("Form", linked_form, "linked_team_id")
+
+    if not frappe.has_permission(
+        doctype="FP Team", ptype="write", doc=linked_team_id, user=frappe.session.user
+    ):
+        frappe.throw(
+            _("You do not have permission to read this form's submissions."),
+            frappe.PermissionError,
+        )
+
+    submission = frappe.get_doc(doctype, submission_id)
+    return submission.as_dict()
+
+
+@frappe.whitelist()
 def get_submission(submission_doctype: str, submission_name: str) -> dict[str, Any]:
     """
-    Get a submission by name
+    Get a submission by name. Used usually by the form owner to view the submission details.
 
     Args:
         submission_name: The name of the submission

--- a/frontend/src/components/form/submissions/SubmissionDetails.vue
+++ b/frontend/src/components/form/submissions/SubmissionDetails.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { createResource } from "frappe-ui";
+import { useManageForm } from "@/stores/form/manageForm";
+import { computed, watch } from "vue";
+import { toast } from "vue-sonner";
+import { formatDateTime } from "@/utils/date";
+import SubmissionFieldValue from "@/components/form/submissions/SubmissionFieldValue.vue";
+
+const props = defineProps<{
+    submissionId: string;
+    doctype: string;
+}>();
+
+const manageFormStore = useManageForm();
+
+const submissionResource = createResource({
+    url: "forms_pro.api.submission.get_submission_response",
+    makeParams() {
+        return {
+            submission_id: props.submissionId,
+            doctype: props.doctype,
+        };
+    },
+    onError(error: Error) {
+        toast.error("Failed to fetch submission details", {
+            description: error.message,
+        });
+    },
+});
+
+const submissionData = computed(() => submissionResource.data ?? null);
+
+watch(
+    () => props.submissionId,
+    (newId) => {
+        if (newId) {
+            submissionResource.fetch();
+        }
+    },
+    { immediate: true }
+);
+
+const gridItems = computed(() => [
+    {
+        label: "Submission ID",
+        key: "name",
+        value: submissionData.value?.name,
+        class: "font-mono",
+    },
+    {
+        label: "Submitted On",
+        key: "creation",
+        value: formatDateTime(submissionData.value?.creation),
+    },
+    {
+        label: "Last Modified",
+        key: "modified",
+        value: formatDateTime(submissionData.value?.modified),
+    },
+    {
+        label: "Submitted By",
+        key: "owner",
+        value: submissionData.value?.owner,
+    },
+]);
+</script>
+
+<template>
+    <div v-if="submissionResource.loading" class="text-sm text-ink-gray-5">Loading...</div>
+    <div v-else-if="submissionData" class="flex flex-col gap-4">
+        <div class="p-2 flex flex-col gap-4">
+            <div class="grid grid-cols-3 gap-4">
+                <template v-for="item in gridItems" :key="item.key">
+                    <span class="text-sm text-ink-gray-5">{{ item.label }}</span>
+                    <span class="text-sm text-ink-gray-7 col-span-2" :class="item.class">{{
+                        item.value
+                    }}</span>
+                </template>
+            </div>
+            <hr />
+            <div class="flex flex-col gap-6 my-4">
+                <SubmissionFieldValue
+                    v-for="field in manageFormStore.formFields"
+                    :key="field.name"
+                    :fieldname="field.fieldname"
+                    :label="field.label"
+                    :description="field.description"
+                    :fieldtype="field.fieldtype"
+                    :value="submissionData[field.fieldname]"
+                />
+            </div>
+        </div>
+    </div>
+</template>

--- a/frontend/src/components/form/submissions/SubmissionFieldValue.vue
+++ b/frontend/src/components/form/submissions/SubmissionFieldValue.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import { Checkbox, Switch, Rating, TextEditor } from "frappe-ui";
+import { FormFieldTypes } from "@/types/formfield";
+import { formatDate, formatDateTime, formatTime } from "@/utils/date";
+import { computed } from "vue";
+
+const props = defineProps<{
+    fieldname: string;
+    label: string;
+    description?: string;
+    fieldtype: FormFieldTypes;
+    value: any;
+}>();
+
+const formattedDateValue = computed(() => {
+    if (!props.value) return "";
+    switch (props.fieldtype) {
+        case FormFieldTypes.Date:
+            return formatDate(props.value);
+        case FormFieldTypes.DateTime:
+            return formatDateTime(props.value);
+        case FormFieldTypes.TimePicker:
+            return formatTime(props.value);
+        case FormFieldTypes.DateRange:
+            try {
+                const dates = JSON.parse(props.value);
+                if (Array.isArray(dates) && dates.length === 2) {
+                    return `${formatDate(dates[0])} – ${formatDate(dates[1])}`;
+                }
+            } catch {
+                /* value might already be a readable string */
+            }
+            return String(props.value);
+        default:
+            return String(props.value);
+    }
+});
+
+const isDateField = computed(() =>
+    [
+        FormFieldTypes.Date,
+        FormFieldTypes.DateTime,
+        FormFieldTypes.DateRange,
+        FormFieldTypes.TimePicker,
+    ].includes(props.fieldtype)
+);
+</script>
+
+<template>
+    <div class="flex flex-col gap-1">
+        <span class="text-sm text-ink-gray-5">{{ label }}</span>
+        <p v-if="description" class="text-xs text-ink-gray-4">{{ description }}</p>
+
+        <Checkbox
+            v-if="fieldtype === FormFieldTypes.Checkbox"
+            :modelValue="Boolean(value)"
+            disabled
+        />
+
+        <Switch
+            v-else-if="fieldtype === FormFieldTypes.Switch"
+            :modelValue="Boolean(value)"
+            disabled
+        />
+
+        <TextEditor
+            v-else-if="fieldtype === FormFieldTypes.TextEditor"
+            :content="value"
+            :editable="false"
+            :bubbleMenu="false"
+            :fixedMenu="false"
+            editorClass="prose-sm !border-none !p-0 !shadow-none"
+        />
+
+        <Rating v-else-if="fieldtype === FormFieldTypes.Rating" :modelValue="value" readonly />
+
+        <a
+            v-else-if="fieldtype === FormFieldTypes.Attach && value"
+            :href="value"
+            target="_blank"
+            class="text-sm text-blue-600 hover:text-blue-700 underline truncate"
+        >
+            {{ value }}
+        </a>
+
+        <span
+            v-else-if="fieldtype === FormFieldTypes.Textarea"
+            class="text-sm text-ink-gray-7 whitespace-pre-wrap"
+        >
+            {{ value }}
+        </span>
+
+        <span v-else-if="isDateField" class="text-sm text-ink-gray-7">
+            {{ formattedDateValue }}
+        </span>
+
+        <span v-else class="text-sm text-ink-gray-7">
+            {{ value ?? "–" }}
+        </span>
+    </div>
+</template>

--- a/frontend/src/components/form/submissions/SubmissionFieldValue.vue
+++ b/frontend/src/components/form/submissions/SubmissionFieldValue.vue
@@ -97,7 +97,7 @@ const classNames = computed<string>(() => {
             v-else-if="fieldtype === FormFieldTypes.Textarea"
             class="text-sm text-ink-gray-7 whitespace-pre-wrap"
         >
-            {{ value }}
+            {{ value ?? "–" }}
         </span>
 
         <span v-else-if="isDateField" class="text-sm text-ink-gray-7">

--- a/frontend/src/components/form/submissions/SubmissionFieldValue.vue
+++ b/frontend/src/components/form/submissions/SubmissionFieldValue.vue
@@ -44,15 +44,25 @@ const isDateField = computed(() =>
         FormFieldTypes.TimePicker,
     ].includes(props.fieldtype)
 );
+
+const classNames = computed<string>(() => {
+    if ([FormFieldTypes.Switch, FormFieldTypes.Checkbox].includes(props.fieldtype)) {
+        return "flex gap-1 flex-row-reverse items-start justify-end";
+    }
+    return "flex flex-col gap-1";
+});
 </script>
 
 <template>
-    <div class="flex flex-col gap-1">
-        <span class="text-sm text-ink-gray-5">{{ label }}</span>
-        <p v-if="description" class="text-xs text-ink-gray-4">{{ description }}</p>
+    <div :class="classNames">
+        <div>
+            <span class="text-sm text-ink-gray-5">{{ label }}</span>
+            <p v-if="description" class="text-xs text-ink-gray-4">{{ description }}</p>
+        </div>
 
         <Checkbox
             v-if="fieldtype === FormFieldTypes.Checkbox"
+            class="mt-1"
             :modelValue="Boolean(value)"
             disabled
         />

--- a/frontend/src/components/form/submissions/SubmissionList.vue
+++ b/frontend/src/components/form/submissions/SubmissionList.vue
@@ -3,8 +3,18 @@ import { useManageForm } from "@/stores/form/manageForm";
 import { ListView, Badge, createResource } from "frappe-ui";
 import { formatDateTime } from "@/utils/date";
 import Avatar from "@/components/ui/Avatar.vue";
+import Drawer from "@/components/ui/Drawer.vue";
+import SubmissionDetails from "@/components/form/submissions/SubmissionDetails.vue";
 import { computed, onMounted, ref } from "vue";
 import { toast } from "vue-sonner";
+
+const drawerOpen = ref(false);
+const selectedSubmission = ref<Record<string, any> | null>(null);
+
+function onRowClick(row: Record<string, any>) {
+    selectedSubmission.value = row;
+    drawerOpen.value = true;
+}
 
 const manageFormStore = useManageForm();
 const isLoading = ref(false);
@@ -67,6 +77,7 @@ const columns = computed(() => [
         :options="{
             selectable: false,
             showTooltip: false,
+            onRowClick,
             emptyState: {
                 title: 'No Submissions Yet',
                 description: 'Submissions for this form will appear here.',
@@ -97,4 +108,12 @@ const columns = computed(() => [
             <span v-else class="text-sm">{{ item }}</span>
         </template>
     </ListView>
+
+    <Drawer v-model="drawerOpen" size="lg" title="Submission Details">
+        <SubmissionDetails
+            v-if="selectedSubmission && manageFormStore.formData?.linked_doctype"
+            :submissionId="selectedSubmission.name"
+            :doctype="manageFormStore.formData.linked_doctype"
+        />
+    </Drawer>
 </template>

--- a/frontend/src/components/form/submissions/SubmissionList.vue
+++ b/frontend/src/components/form/submissions/SubmissionList.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { useManageForm } from "@/stores/form/manageForm";
+import { ListView, Badge, createResource } from "frappe-ui";
+import { formatDateTime } from "@/utils/date";
+import Avatar from "@/components/ui/Avatar.vue";
+import { computed, onMounted, ref } from "vue";
+import { toast } from "vue-sonner";
+
+const manageFormStore = useManageForm();
+const isLoading = ref(false);
+
+const allSubmissionsResource = createResource({
+    url: "forms_pro.api.submission.get_all_submissions",
+    makeParams() {
+        return {
+            form_id: manageFormStore.currentFormId,
+        };
+    },
+    onSuccess() {
+        isLoading.value = false;
+    },
+    onError(error: Error) {
+        toast.error("Failed to fetch submissions", {
+            description: error.message,
+        });
+    },
+});
+const allSubmissions = computed(() => allSubmissionsResource.data ?? []);
+
+onMounted(() => {
+    isLoading.value = true;
+    allSubmissionsResource.fetch();
+});
+
+const columns = computed(() => [
+    {
+        label: "ID",
+        key: "name",
+        width: 1,
+    },
+    {
+        label: "Status",
+        key: "submission_status",
+        width: 1,
+    },
+    {
+        label: "Submitted On",
+        key: "creation",
+        width: 2,
+    },
+    {
+        label: "Last Modified",
+        key: "modified",
+        width: 2,
+    },
+    {
+        label: "Submitted By",
+        key: "owner",
+        width: 1,
+    },
+]);
+</script>
+<template>
+    <ListView
+        :columns="columns"
+        :rows="allSubmissions"
+        :options="{
+            selectable: false,
+            showTooltip: false,
+            emptyState: {
+                title: 'No Submissions Yet',
+                description: 'Submissions for this form will appear here.',
+            },
+        }"
+        row-key="name"
+    >
+        <!-- @vue-expect-error -->
+        <template #cell="{ item, row, column }">
+            <div v-if="column.key === 'owner'" class="flex items-center gap-2">
+                <Avatar v-if="row.owner !== 'Guest'" :userId="row.owner" />
+                <span class="text-sm text-ink-gray-8">{{ row.owner }}</span>
+            </div>
+            <span v-else-if="column.key === 'name'" class="text-xs text-ink-gray-6 font-mono">
+                {{ row.name }}
+            </span>
+            <Badge
+                v-else-if="column.key === 'submission_status'"
+                :label="row.submission_status"
+                :variant="row.submission_status === 'Submitted' ? 'subtle' : 'outline'"
+            />
+            <span v-else-if="column.key === 'creation'" class="text-sm text-ink-gray-6">
+                {{ formatDateTime(row.creation) }}
+            </span>
+            <span v-else-if="column.key === 'modified'" class="text-sm text-ink-gray-6">
+                {{ formatDateTime(row.modified) }}
+            </span>
+            <span v-else class="text-sm">{{ item }}</span>
+        </template>
+    </ListView>
+</template>

--- a/frontend/src/components/form/submissions/SubmissionList.vue
+++ b/frontend/src/components/form/submissions/SubmissionList.vue
@@ -17,7 +17,6 @@ function onRowClick(row: Record<string, any>) {
 }
 
 const manageFormStore = useManageForm();
-const isLoading = ref(false);
 
 const allSubmissionsResource = createResource({
     url: "forms_pro.api.submission.get_all_submissions",
@@ -25,9 +24,6 @@ const allSubmissionsResource = createResource({
         return {
             form_id: manageFormStore.currentFormId,
         };
-    },
-    onSuccess() {
-        isLoading.value = false;
     },
     onError(error: Error) {
         toast.error("Failed to fetch submissions", {
@@ -38,7 +34,6 @@ const allSubmissionsResource = createResource({
 const allSubmissions = computed(() => allSubmissionsResource.data ?? []);
 
 onMounted(() => {
-    isLoading.value = true;
     allSubmissionsResource.fetch();
 });
 

--- a/frontend/src/components/form/submissions/SubmissionList.vue
+++ b/frontend/src/components/form/submissions/SubmissionList.vue
@@ -110,5 +110,6 @@ const columns = computed(() => [
             :submissionId="selectedSubmission.name"
             :doctype="manageFormStore.formData.linked_doctype"
         />
+        <div v-else-if="selectedSubmission" class="text-sm text-ink-gray-5">Loading...</div>
     </Drawer>
 </template>

--- a/frontend/src/components/ui/Drawer.vue
+++ b/frontend/src/components/ui/Drawer.vue
@@ -95,6 +95,7 @@ const transitionName = computed(() => `drawer-${props.position}`);
                 v-if="open"
                 role="dialog"
                 aria-modal="true"
+                :aria-labelledby="title ? 'drawer-title' : undefined"
                 :class="panelClasses"
                 class="fixed z-50 flex flex-col bg-surface-modal shadow-2xl"
             >
@@ -108,6 +109,7 @@ const transitionName = computed(() => `drawer-${props.position}`);
                     <slot name="title">
                         <h3
                             v-if="title"
+                            id="drawer-title"
                             class="text-lg font-semibold text-ink-gray-9 truncate pr-2"
                         >
                             {{ title }}

--- a/frontend/src/components/ui/Drawer.vue
+++ b/frontend/src/components/ui/Drawer.vue
@@ -13,7 +13,7 @@ export interface DrawerAction {
 
 const props = withDefaults(
     defineProps<{
-        size?: "sm" | "md" | "lg";
+        size?: "sm" | "md" | "lg" | "xl";
         position?: "top" | "bottom" | "right" | "left";
         title?: string | null;
         actions?: DrawerAction[] | null;
@@ -60,8 +60,8 @@ const panelClasses = computed(() => {
     const isHorizontal = props.position === "left" || props.position === "right";
 
     const sizeClasses = {
-        horizontal: { sm: "w-80", md: "w-[26rem]", lg: "w-[35rem]" },
-        vertical: { sm: "h-[30vh]", md: "h-[50vh]", lg: "h-[70vh]" },
+        horizontal: { sm: "w-80", md: "w-[26rem]", lg: "w-[35rem]", xl: "w-[50rem]" },
+        vertical: { sm: "h-[30vh]", md: "h-[50vh]", lg: "h-[70vh]", xl: "h-[90vh]" },
     };
 
     const orientation = isHorizontal ? "horizontal" : "vertical";

--- a/frontend/src/components/ui/Drawer.vue
+++ b/frontend/src/components/ui/Drawer.vue
@@ -1,0 +1,201 @@
+<script setup lang="ts">
+import { computed, watch, onUnmounted, useSlots } from "vue";
+import { Button } from "frappe-ui";
+
+export interface DrawerAction {
+    label: string;
+    variant?: "solid" | "outline" | "ghost" | "subtle";
+    theme?: "gray" | "blue" | "green" | "red";
+    onClick?: (close: () => void) => void;
+    disabled?: boolean;
+    loading?: boolean;
+}
+
+const props = withDefaults(
+    defineProps<{
+        size?: "sm" | "md" | "lg";
+        position?: "top" | "bottom" | "right" | "left";
+        title?: string | null;
+        actions?: DrawerAction[] | null;
+    }>(),
+    {
+        size: "md",
+        position: "right",
+        title: null,
+        actions: null,
+    }
+);
+
+const slots = useSlots();
+const open = defineModel<boolean>({ default: false });
+
+function close() {
+    open.value = false;
+}
+
+function onKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") close();
+}
+
+watch(open, (isOpen) => {
+    if (isOpen) {
+        document.addEventListener("keydown", onKeydown);
+        document.body.style.overflow = "hidden";
+    } else {
+        document.removeEventListener("keydown", onKeydown);
+        document.body.style.overflow = "";
+    }
+});
+
+onUnmounted(() => {
+    document.removeEventListener("keydown", onKeydown);
+    document.body.style.overflow = "";
+});
+
+const showActions = computed(() => {
+    return (props.actions && props.actions.length > 0) || !!slots.actions;
+});
+
+const panelClasses = computed(() => {
+    const isHorizontal = props.position === "left" || props.position === "right";
+
+    const sizeClasses = {
+        horizontal: { sm: "w-80", md: "w-[26rem]", lg: "w-[35rem]" },
+        vertical: { sm: "h-[30vh]", md: "h-[50vh]", lg: "h-[70vh]" },
+    };
+
+    const orientation = isHorizontal ? "horizontal" : "vertical";
+    const dimension = sizeClasses[orientation][props.size];
+
+    const positionClasses = {
+        right: `top-0 right-0 h-full ${dimension} max-w-[90vw]`,
+        left: `top-0 left-0 h-full ${dimension} max-w-[90vw]`,
+        top: `top-0 left-0 w-full ${dimension} max-h-[90vh]`,
+        bottom: `bottom-0 left-0 w-full ${dimension} max-h-[90vh]`,
+    };
+
+    return positionClasses[props.position];
+});
+
+const transitionName = computed(() => `drawer-${props.position}`);
+</script>
+
+<template>
+    <Teleport to="body">
+        <Transition name="drawer-overlay" appear>
+            <div
+                v-if="open"
+                class="fixed inset-0 z-50 bg-black/30 dark:bg-black/50"
+                @click="close"
+            />
+        </Transition>
+
+        <Transition :name="transitionName" appear>
+            <div
+                v-if="open"
+                role="dialog"
+                aria-modal="true"
+                :class="panelClasses"
+                class="fixed z-50 flex flex-col bg-surface-modal shadow-2xl"
+            >
+                <!-- Title -->
+                <div
+                    class="flex items-center justify-between shrink-0 px-5 py-3.5"
+                    :class="{
+                        'border-b border-surface-gray-2': title || $slots.title,
+                    }"
+                >
+                    <slot name="title">
+                        <h3
+                            v-if="title"
+                            class="text-lg font-semibold text-ink-gray-9 truncate pr-2"
+                        >
+                            {{ title }}
+                        </h3>
+                    </slot>
+                    <Button
+                        variant="ghost"
+                        icon="x"
+                        size="sm"
+                        class="ml-auto shrink-0"
+                        @click="close"
+                    />
+                </div>
+
+                <!-- Body -->
+                <div class="flex-1 overflow-y-auto px-5 py-4">
+                    <slot />
+                </div>
+
+                <!-- Actions -->
+                <div
+                    v-if="showActions"
+                    class="shrink-0 border-t border-surface-gray-2 px-5 py-3.5"
+                >
+                    <slot name="actions" :close="close">
+                        <div class="flex items-center justify-end gap-2">
+                            <Button
+                                v-for="(action, index) in actions"
+                                :key="index"
+                                :variant="action.variant ?? 'outline'"
+                                :theme="action.theme"
+                                :disabled="action.disabled"
+                                :loading="action.loading"
+                                @click="action.onClick?.(close)"
+                            >
+                                {{ action.label }}
+                            </Button>
+                        </div>
+                    </slot>
+                </div>
+            </div>
+        </Transition>
+    </Teleport>
+</template>
+
+<style scoped>
+.drawer-overlay-enter-active {
+    transition: opacity 0.3s ease;
+}
+.drawer-overlay-leave-active {
+    transition: opacity 0.2s ease;
+}
+.drawer-overlay-enter-from,
+.drawer-overlay-leave-to {
+    opacity: 0;
+}
+
+.drawer-right-enter-active,
+.drawer-left-enter-active,
+.drawer-top-enter-active,
+.drawer-bottom-enter-active {
+    transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.drawer-right-leave-active,
+.drawer-left-leave-active,
+.drawer-top-leave-active,
+.drawer-bottom-leave-active {
+    transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.drawer-right-enter-from,
+.drawer-right-leave-to {
+    transform: translateX(100%);
+}
+
+.drawer-left-enter-from,
+.drawer-left-leave-to {
+    transform: translateX(-100%);
+}
+
+.drawer-top-enter-from,
+.drawer-top-leave-to {
+    transform: translateY(-100%);
+}
+
+.drawer-bottom-enter-from,
+.drawer-bottom-leave-to {
+    transform: translateY(100%);
+}
+</style>

--- a/frontend/src/pages/manage/ManageForm.vue
+++ b/frontend/src/pages/manage/ManageForm.vue
@@ -1,79 +1,25 @@
 <script setup lang="ts">
 import BaseLayout from "@/layouts/BaseLayout.vue";
-import { ArrowLeft, LayoutGrid } from "lucide-vue-next";
-import { Breadcrumbs } from "frappe-ui";
-import { ref, computed, watch } from "vue";
+import { watch } from "vue";
 import { useManageForm } from "@/stores/form/manageForm";
-import { useRoute, useRouter } from "vue-router";
+import { useRoute } from "vue-router";
+import { useManageFormSidebarItems } from "./sidebarItems";
 
 const manageFormStore = useManageForm();
 const route = useRoute();
-const router = useRouter();
+const sidebarItems = useManageFormSidebarItems();
 
 watch(
     () => route.params.id,
-    () => {
-        manageFormStore.initialize(route.params.id as string);
+    (id) => {
+        manageFormStore.initialize(id as string);
     },
     { immediate: true }
 );
-
-const sidebarSections = ref<any[]>([
-    {
-        items: [
-            {
-                label: "Go Back",
-                icon: ArrowLeft,
-                onClick: () => {
-                    router.replace("/");
-                },
-            },
-        ],
-    },
-    {
-        label: "",
-        items: [
-            {
-                label: "Overview",
-                to: `/manage/${manageFormStore.currentFormId}/overview`,
-                isActive: true,
-                icon: LayoutGrid,
-            },
-        ],
-    },
-]);
-
-const breadcrumbItems = computed(() => {
-    const _items = [
-        {
-            label: "Manage Form",
-            to: `/manage/${manageFormStore.currentFormId}`,
-            isActive: true,
-        },
-    ];
-
-    sidebarSections.value.forEach((section: any) => {
-        section.items.forEach((item: any) => {
-            if (item.isActive) {
-                _items.push({
-                    label: item.label,
-                    to: item.to,
-                    isActive: item.isActive,
-                });
-            }
-        });
-    });
-
-    return _items;
-});
 </script>
+
 <template>
-    <BaseLayout :sidebar-sections="sidebarSections">
-        <div class="space-y-4 w-full bg-surface-white flex justify-center">
-            <div class="max-w-screen-lg mx-auto w-full space-y-4">
-                <Breadcrumbs :items="breadcrumbItems" />
-                <RouterView />
-            </div>
-        </div>
+    <BaseLayout :sidebar-sections="sidebarItems">
+        <router-view />
     </BaseLayout>
 </template>

--- a/frontend/src/pages/manage/overview/Overview.vue
+++ b/frontend/src/pages/manage/overview/Overview.vue
@@ -4,11 +4,17 @@ import DescriptionSection from "@/components/form/manage/DescriptionSection.vue"
 import { useManageForm } from "@/stores/form/manageForm";
 import { FileText, CaseLower, Lock } from "lucide-vue-next";
 import { formatPrettyDate } from "@/utils/date";
-import { TabButtons, LoadingText, Badge } from "frappe-ui";
+import { TabButtons, LoadingText, Badge, Breadcrumbs } from "frappe-ui";
 import Avatar from "@/components/ui/Avatar.vue";
 import { useQueryParam } from "@/composables/useQueryParam";
+import { computed } from "vue";
 
 const manageFormStore = useManageForm();
+
+const breadcrumbItems = computed(() => [
+    { label: "Manage Form", to: `/manage/${manageFormStore.currentFormId}/overview` },
+    { label: "Overview" },
+]);
 
 const tabs = [
     {
@@ -30,11 +36,12 @@ const selectedTab = useQueryParam<TabValue>("tab", "description", validTabValues
 </script>
 
 <template>
-    <div v-if="manageFormStore.formResource.value?.loading">
-        <LoadingText />
-    </div>
-    <div v-if="manageFormStore.formData">
-        <div class="flex flex-col gap-3">
+    <div class="flex flex-col gap-4 w-full overflow-y-auto">
+        <Breadcrumbs :items="breadcrumbItems" />
+        <div v-if="manageFormStore.formResource.value?.loading">
+            <LoadingText />
+        </div>
+        <div v-else-if="manageFormStore.formData" class="flex flex-col gap-3">
             <Badge
                 v-if="manageFormStore.formData?.is_published"
                 class="w-fit"

--- a/frontend/src/pages/manage/sidebarItems.ts
+++ b/frontend/src/pages/manage/sidebarItems.ts
@@ -1,0 +1,45 @@
+import { ArrowLeft, LayoutGrid, ListChecks } from "lucide-vue-next";
+import { computed } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import type { SidebarProps } from "frappe-ui";
+
+type SidebarSectionProps = NonNullable<
+  SidebarProps["sections"]
+> extends (infer T)[]
+  ? T
+  : never;
+
+export function useManageFormSidebarItems() {
+  const route = useRoute();
+  const router = useRouter();
+  const formId = computed(() => route.params.id as string);
+
+  return computed((): SidebarSectionProps[] => [
+    {
+      items: [
+        {
+          label: "Go Back",
+          icon: ArrowLeft,
+          onClick: () => router.replace("/"),
+        },
+      ],
+    },
+    {
+      label: "",
+      items: [
+        {
+          label: "Overview",
+          to: `/manage/${formId.value}/overview`,
+          icon: LayoutGrid,
+          isActive: route.name === "Manage Form Overview",
+        },
+        {
+          label: "Submissions",
+          to: `/manage/${formId.value}/submissions`,
+          icon: ListChecks,
+          isActive: route.name === "Manage Form Submissions",
+        },
+      ],
+    },
+  ]);
+}

--- a/frontend/src/pages/manage/submissions/Submissions.vue
+++ b/frontend/src/pages/manage/submissions/Submissions.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { useManageForm } from "@/stores/form/manageForm";
+import { ListChecks } from "lucide-vue-next";
+import { Breadcrumbs, LoadingText } from "frappe-ui";
+import { computed } from "vue";
+
+const manageFormStore = useManageForm();
+
+const breadcrumbItems = computed(() => [
+    { label: "Manage Form", to: `/manage/${manageFormStore.currentFormId}/overview` },
+    { label: "Submissions" },
+]);
+</script>
+
+<template>
+    <div class="flex flex-col gap-4 w-full overflow-y-auto">
+        <Breadcrumbs :items="breadcrumbItems" />
+        <div v-if="manageFormStore.formResource.value?.loading">
+            <LoadingText />
+        </div>
+        <div v-else-if="manageFormStore.formData" class="flex flex-col gap-4">
+            <div class="flex gap-3 items-center text-ink-gray-8">
+                <ListChecks class="w-6 h-6" />
+                <h2 class="text-2xl font-bold">Submissions</h2>
+            </div>
+            <p class="text-ink-gray-5 text-sm">
+                Form submissions for {{ manageFormStore.formData?.title }} will appear here.
+            </p>
+        </div>
+    </div>
+</template>

--- a/frontend/src/pages/manage/submissions/Submissions.vue
+++ b/frontend/src/pages/manage/submissions/Submissions.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { useManageForm } from "@/stores/form/manageForm";
 import { ListChecks } from "lucide-vue-next";
-import { Breadcrumbs, LoadingText } from "frappe-ui";
+import { Breadcrumbs } from "frappe-ui";
 import { computed } from "vue";
+import SubmissionList from "@/components/form/submissions/SubmissionList.vue";
 
 const manageFormStore = useManageForm();
-
 const breadcrumbItems = computed(() => [
     { label: "Manage Form", to: `/manage/${manageFormStore.currentFormId}/overview` },
     { label: "Submissions" },
@@ -13,19 +13,21 @@ const breadcrumbItems = computed(() => [
 </script>
 
 <template>
-    <div class="flex flex-col gap-4 w-full overflow-y-auto">
+    <div class="flex flex-col gap-4 w-full">
         <Breadcrumbs :items="breadcrumbItems" />
-        <div v-if="manageFormStore.formResource.value?.loading">
-            <LoadingText />
-        </div>
-        <div v-else-if="manageFormStore.formData" class="flex flex-col gap-4">
+        <div class="flex flex-col gap-4">
             <div class="flex gap-3 items-center text-ink-gray-8">
                 <ListChecks class="w-6 h-6" />
                 <h2 class="text-2xl font-bold">Submissions</h2>
             </div>
             <p class="text-ink-gray-5 text-sm">
-                Form submissions for {{ manageFormStore.formData?.title }} will appear here.
+                Form submissions for
+                <span class="text-sm p-1 bg-surface-gray-1 font-mono">{{
+                    manageFormStore.formData?.title
+                }}</span>
+                will appear here.
             </p>
+            <SubmissionList />
         </div>
     </div>
 </template>

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -32,6 +32,11 @@ const routes: RouteRecordRaw[] = [
         name: "Manage Form Overview",
         component: () => import("@/pages/manage/overview/Overview.vue"),
       },
+      {
+        path: "submissions",
+        name: "Manage Form Submissions",
+        component: () => import("@/pages/manage/submissions/Submissions.vue"),
+      },
     ],
   },
   {


### PR DESCRIPTION
## Overview

Adds a **Submissions** section to the form management area, letting form owners browse all submissions, see metadata at a glance, and inspect individual responses field-by-field in a slide-over panel.

## Changes

### Backend (`forms_pro/api/submission.py`)
- **`get_all_submissions(form_id)`** — new whitelisted endpoint that returns all `Submitted` entries for a form. Gated behind team `write` permission so only team members can access it.
- **`get_submission_response(submission_id, doctype)`** — new whitelisted endpoint to fetch a single submission's full document, with the same team-based permission check.
- Added `owner` field to `UserSubmissionResponse` so the submitter's identity is available in list and detail views.

### Frontend

**New reusable component — `Drawer.vue`**
- Slide-over panel that teleports to `<body>` with a backdrop.
- Props: `size` (`sm` / `md` / `lg` / `xl`), `position` (`right` / `left` / `top` / `bottom`), `title`, `actions`.
- Closes on Escape key or backdrop click; locks body scroll while open.
- Smooth enter/leave transitions per position direction.

**Submissions UI (`components/form/submissions/`)**
- `SubmissionList.vue` — `ListView` displaying all submissions with status badge, formatted timestamps, and owner avatar. Clicking a row opens the Drawer with full details.
- `SubmissionDetails.vue` — shows submission metadata (ID, submitted on, last modified, submitted by) followed by every form field rendered through `SubmissionFieldValue`.
- `SubmissionFieldValue.vue` — renders a field's value according to its type: `Checkbox` / `Switch` (read-only toggle), `Rating`, `TextEditor` (non-editable), `Attach` (clickable link), `Textarea` (pre-wrapped), date/time variants (formatted), and a plain text fallback.

**Navigation & routing**
- Extracted sidebar config into `useManageFormSidebarItems()` composable (`sidebarItems.ts`) with reactive `isActive` driven by the current route name. Added a **Submissions** nav item alongside Overview.
- `ManageForm.vue` simplified — sidebar config and breadcrumb logic moved out to the composable and individual page components respectively.
- `Overview.vue` now owns its own breadcrumb and uses `v-else-if` for correct conditional rendering.
- New `Submissions.vue` page component and a `/manage/:id/submissions` route registered in `router.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a submissions management interface to view all form submissions in a dedicated list view
  * Enabled viewing detailed submission information including metadata, timestamps, and field values
  * Introduced a drawer component for expanding and displaying submission details
  * Added "Submissions" navigation option in the form management sidebar with breadcrumb navigation support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->