### PR TITLE
feat(multiselect): add Multiselect field with registry-driven builder extras

### DIFF
--- a/.claude/skills/add-field/SKILL.md
+++ b/.claude/skills/add-field/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: add-field
+description: Add a new field type to Forms Pro end-to-end (backend doctype, Python mapping, submission handling, frontend component, fieldTypes registry, options resolution, and submission display).
+argument-hint: <FieldtypeName> e.g. "Signature"
+---
+
+You are adding a new field type to Forms Pro. The field type name is: **$ARGUMENTS**
+
+Work through each step below in order. Commit in three logical batches at the end (backend doctype, backend submission, frontend).
+
+---
+
+## Step 1 — Understand the codebase conventions
+
+Read the following files before making any changes so you understand the patterns:
+
+- `forms_pro/forms_pro/doctype/form_field/form_field.py` — `FORM_TO_FRAPPE_FIELDTYPE` dict and `DF.Literal` type hint block
+- `forms_pro/forms_pro/doctype/form_field/form_field.json` — the `fieldtype` Select field's `options` string
+- `frontend/src/types/FormsPro/form_field.types.ts` — `Fieldtype` enum
+- `frontend/src/config/fieldTypes.ts` — `FIELD_TYPE_DEFINITIONS` array
+- `frontend/src/utils/selectOptions.ts` — `getFieldOptions` function
+- `frontend/src/components/form/submissions/SubmissionFieldValue.vue` — submission display cases
+- `forms_pro/api/submission.py` — `submit_form_response` and `_validate_form_response`
+
+---
+
+## Step 2 — Backend: doctype
+
+**`forms_pro/forms_pro/doctype/form_field/form_field.json`**
+- Add `\n<FieldtypeName>` to the end of the `options` string of the `fieldtype` Select field.
+- Update the `modified` timestamp to today's date.
+
+**`forms_pro/forms_pro/doctype/form_field/form_field.py`**
+- Add an entry to `FORM_TO_FRAPPE_FIELDTYPE`:
+  ```python
+  "<FieldtypeName>": {"fieldtype": "<FrappeFieldtype>"},
+  ```
+  Choose the appropriate Frappe fieldtype. Common mappings:
+  - Scalar text → `"Data"` or `"Small Text"`
+  - Multi-value JSON array → `"JSON"`
+  - Boolean → `"Check"`
+  - Number → `"Int"` or `"Float"`
+- Add `"<FieldtypeName>"` to the `DF.Literal[...]` type hint list inside the `TYPE_CHECKING` block.
+
+---
+
+## Step 3 — Backend: submission serialization
+
+Open `forms_pro/api/submission.py` and check whether the new field's value type could arrive as a Python `list` from Frappe's request deserialization (this happens for `JSON` array fields like Multiselect).
+
+If yes, the existing guard in `submit_form_response` already handles it:
+```python
+if isinstance(value, list):
+    value = json.dumps(value)
+```
+No change needed there.
+
+Also check `_validate_form_response`: if an empty value for the new field type can be represented as something other than `None`/`""`/`[]` (e.g. an empty dict `{}`), add it to the `is_empty` check:
+```python
+is_empty = value is None or value == "" or value == [] or ...
+```
+
+---
+
+## Step 4 — Frontend: types
+
+**`frontend/src/types/FormsPro/form_field.types.ts`**
+- Add the new enum member to `Fieldtype`:
+  ```ts
+  "<SCREAMING_SNAKE>" = "<FieldtypeName>",
+  ```
+  The enum key must be SCREAMING_SNAKE_CASE; the value must exactly match the Python/JSON string.
+
+---
+
+## Step 5 — Frontend: Vue component
+
+Create `frontend/src/components/fields/<FieldtypeName>.vue`.
+
+Contract the component must follow:
+- `v-model` / `defineModel` for the field value (type depends on the field — `string`, `string[]`, `number`, etc.)
+- `options?: string[]` prop if the field consumes options (like Select or Multiselect)
+- `disabled?: boolean` prop for read-only mode in submission view / edit mode preview
+
+If you are writing a scaffold (placeholder), keep it minimal but functional — render the value in read mode and a basic input in edit mode. The user will replace it with the real component.
+
+---
+
+## Step 6 — Frontend: field type registry
+
+**`frontend/src/config/fieldTypes.ts`**
+- Import the new component at the top alongside the other field imports.
+- Add an entry to `FIELD_TYPE_DEFINITIONS`:
+  ```ts
+  {
+    name: Fieldtype.<SCREAMING_SNAKE>,
+    component: <ComponentName>,
+    props: {},           // default props forwarded to the component
+    layout: "default",   // or "inline" / "description-first" / "custom"
+    frappeFieldtype: "<FrappeFieldtype>",
+    isBoolean: false,    // true only for Switch / Checkbox analogues
+    isDate: false,       // true only for Date / DateTime / DateRange / Time analogues
+  },
+  ```
+
+  Layout guide:
+  - `"default"` — label top, input below, description at bottom (most fields)
+  - `"inline"` — input first, label to the right (Switch, Checkbox)
+  - `"description-first"` — label, description, then input (Text Editor)
+  - `"custom"` — component owns its full layout (Table, Attach)
+
+---
+
+## Step 7 — Frontend: options resolution
+
+**`frontend/src/utils/selectOptions.ts`** — `getFieldOptions`
+
+If the new field type uses newline-separated options (like Select / Multiselect), add `"<FieldtypeName>"` to the existing condition:
+```ts
+if (field.fieldtype === "Select" || field.fieldtype === "Multiselect" || field.fieldtype === "<FieldtypeName>") {
+  return field.options.split("\n");
+}
+```
+If it uses a Link-style async lookup or no options at all, adjust or skip accordingly.
+
+---
+
+## Step 8 — Frontend: submission display
+
+**`frontend/src/components/form/submissions/SubmissionFieldValue.vue`**
+
+Add a display case before the generic `v-else` fallback. Examples:
+
+- For a JSON array field:
+  ```ts
+  const parsed<Name>Value = computed(() => {
+    if (!props.value) return "–";
+    try {
+      const parsed = JSON.parse(props.value);
+      if (Array.isArray(parsed)) return parsed.join(", ");
+    } catch { /* already a string */ }
+    return String(props.value);
+  });
+  ```
+  ```vue
+  <span v-else-if="fieldtype === Fieldtype.<SCREAMING_SNAKE>" class="text-sm text-ink-gray-7">
+    {{ parsed<Name>Value }}
+  </span>
+  ```
+
+- For a simple scalar, the generic `v-else` fallback already handles it — no change needed.
+
+---
+
+## Step 9 — Typecheck
+
+Run:
+```bash
+cd frontend && yarn typecheck
+```
+
+Fix any TypeScript errors before committing. Common issues:
+- Forgot to add the enum member to `Fieldtype`
+- `FIELD_TYPE_DEFINITIONS` exhaustiveness error — TypeScript will point to the missing entry
+
+---
+
+## Step 10 — Commit
+
+Create three commits (no co-author line):
+
+1. `feat(form-field): add <FieldtypeName> fieldtype to doctype and backend mapping`
+   - `form_field.json`, `form_field.py`
+
+2. `fix(submission): <any submission serialization changes>` *(skip if no changes needed)*
+
+3. `feat(<fieldtype-kebab>): wire up <FieldtypeName> field across the frontend`
+   - `form_field.types.ts`, `fieldTypes.ts`, `<FieldtypeName>.vue`, `selectOptions.ts`, `SubmissionFieldValue.vue`

--- a/.claude/skills/userinterface-wiki/AGENTS.md
+++ b/.claude/skills/userinterface-wiki/AGENTS.md
@@ -1,0 +1,3749 @@
+# User Interface Wiki
+
+**Version 3.0.0**
+raphael-salaja
+March 2026
+
+> **Note:**
+> This document is mainly for agents and LLMs to follow when reviewing,
+> generating, or refactoring UI code. Humans may also find it useful, but
+> guidance here is optimized for automation and consistency by AI-assisted workflows.
+
+---
+
+## Abstract
+
+Comprehensive UI/UX best practices guide for web interfaces, designed for AI agents and LLMs. Contains 152 rules across 12 categories, prioritized by impact from critical (animation principles, timing functions) to incremental (morphing icons, typography). Each rule includes detailed explanations and code examples comparing incorrect vs. correct implementations.
+
+---
+
+## Table of Contents
+
+1. [Animation Principles](#1-animation-principles) — **CRITICAL**
+   - 1.1 [User Animations Under 300ms](#11-user-animations-under-300ms)
+   - 1.2 [Consistent Timing for Similar Elements](#12-consistent-timing-for-similar-elements)
+   - 1.3 [No Entrance Animation on Context Menus](#13-no-entrance-animation-on-context-menus)
+   - 1.4 [Exponential Ramps for Natural Decay](#14-exponential-ramps-for-natural-decay)
+   - 1.5 [No Linear Easing for Motion](#15-no-linear-easing-for-motion)
+   - 1.6 [Active State Scale Transform](#16-active-state-scale-transform)
+   - 1.7 [Subtle Squash and Stretch](#17-subtle-squash-and-stretch)
+   - 1.8 [Springs for Overshoot and Settle](#18-springs-for-overshoot-and-settle)
+   - 1.9 [Stagger Under 50ms Per Item](#19-stagger-under-50ms-per-item)
+   - 1.10 [Single Focal Point](#110-single-focal-point)
+   - 1.11 [Dim Background for Focus](#111-dim-background-for-focus)
+   - 1.12 [Z-Index Layering for Animated Elements](#112-z-index-layering-for-animated-elements)
+2. [Timing Functions](#2-timing-functions) — **HIGH**
+   - 2.1 [Springs for Gesture-Driven Motion](#21-springs-for-gesture-driven-motion)
+   - 2.2 [Springs for Interruptible Motion](#22-springs-for-interruptible-motion)
+   - 2.3 [Springs Preserve Input Velocity](#23-springs-preserve-input-velocity)
+   - 2.4 [Balanced Spring Parameters](#24-balanced-spring-parameters)
+   - 2.5 [Easing for System State Changes](#25-easing-for-system-state-changes)
+   - 2.6 [Ease-Out for Entrances](#26-ease-out-for-entrances)
+   - 2.7 [Ease-In for Exits](#27-ease-in-for-exits)
+   - 2.8 [Ease-In-Out for View Transitions](#28-ease-in-out-for-view-transitions)
+   - 2.9 [Linear Easing Only for Progress](#29-linear-easing-only-for-progress)
+   - 2.10 [Press and Hover 120-180ms](#210-press-and-hover-120-180ms)
+   - 2.11 [Small State Changes 180-260ms](#211-small-state-changes-180-260ms)
+   - 2.12 [Max 300ms for User Actions](#212-max-300ms-for-user-actions)
+   - 2.13 [Shorten Duration Before Adjusting Curve](#213-shorten-duration-before-adjusting-curve)
+   - 2.14 [No Animation for High-Frequency Interactions](#214-no-animation-for-high-frequency-interactions)
+   - 2.15 [No Animation for Keyboard Navigation](#215-no-animation-for-keyboard-navigation)
+   - 2.16 [No Entrance Animation for Context Menus](#216-no-entrance-animation-for-context-menus)
+3. [Exit Animations](#3-exit-animations) — **HIGH**
+   - 3.1 [AnimatePresence Wrapper Required](#31-animatepresence-wrapper-required)
+   - 3.2 [Exit Prop Required Inside AnimatePresence](#32-exit-prop-required-inside-animatepresence)
+   - 3.3 [Unique Keys in AnimatePresence Lists](#33-unique-keys-in-animatepresence-lists)
+   - 3.4 [Exit Mirrors Initial for Symmetry](#34-exit-mirrors-initial-for-symmetry)
+   - 3.5 [useIsPresent in Child Component](#35-useispresent-in-child-component)
+   - 3.6 [Call safeToRemove After Async Work](#36-call-safetoremove-after-async-work)
+   - 3.7 [Disable Interactions on Exiting Elements](#37-disable-interactions-on-exiting-elements)
+   - 3.8 [Mode "wait" Doubles Duration](#38-mode-wait-doubles-duration)
+   - 3.9 [Mode "sync" Causes Layout Conflicts](#39-mode-sync-causes-layout-conflicts)
+   - 3.10 [popLayout for List Reordering](#310-poplayout-for-list-reordering)
+   - 3.11 [Propagate Prop for Nested AnimatePresence](#311-propagate-prop-for-nested-animatepresence)
+   - 3.12 [Coordinated Parent-Child Exit Timing](#312-coordinated-parent-child-exit-timing)
+4. [CSS Pseudo Elements](#4-css-pseudo-elements) — **MEDIUM**
+   - 4.1 [Content Property Required for Pseudo-Elements](#41-content-property-required-for-pseudo-elements)
+   - 4.2 [Pseudo-Elements Over DOM Nodes](#42-pseudo-elements-over-dom-nodes)
+   - 4.3 [Position Relative Parent for Pseudo-Elements](#43-position-relative-parent-for-pseudo-elements)
+   - 4.4 [Z-Index Layering for Pseudo-Elements](#44-z-index-layering-for-pseudo-elements)
+   - 4.5 [Hit Target Expansion with Pseudo-Elements](#45-hit-target-expansion-with-pseudo-elements)
+   - 4.6 [View Transition Name Required](#46-view-transition-name-required)
+   - 4.7 [Unique View Transition Names](#47-unique-view-transition-names)
+   - 4.8 [Clean Up View Transition Names](#48-clean-up-view-transition-names)
+   - 4.9 [View Transitions Over JS Libraries](#49-view-transitions-over-js-libraries)
+   - 4.10 [Style View Transition Pseudo-Elements](#410-style-view-transition-pseudo-elements)
+   - 4.11 [Use ::backdrop for Dialog Backgrounds](#411-use-backdrop-for-dialog-backgrounds)
+   - 4.12 [Use ::placeholder for Input Styling](#412-use-placeholder-for-input-styling)
+   - 4.13 [Use ::selection for Text Styling](#413-use-selection-for-text-styling)
+   - 4.14 [Use ::marker for Custom List Bullets](#414-use-marker-for-custom-list-bullets)
+   - 4.15 [Use ::first-line for Typographic Treatments](#415-use-first-line-for-typographic-treatments)
+5. [Audio Feedback](#5-audio-feedback) — **MEDIUM**
+   - 5.1 [Visual Equivalent for Every Sound](#51-visual-equivalent-for-every-sound)
+   - 5.2 [Toggle Setting to Disable Sounds](#52-toggle-setting-to-disable-sounds)
+   - 5.3 [Respect prefers-reduced-motion for Sound](#53-respect-prefers-reduced-motion-for-sound)
+   - 5.4 [Independent Volume Control](#54-independent-volume-control)
+   - 5.5 [No Sound on High-Frequency Interactions](#55-no-sound-on-high-frequency-interactions)
+   - 5.6 [Sound for Confirmations](#56-sound-for-confirmations)
+   - 5.7 [Sound for Errors and Warnings](#57-sound-for-errors-and-warnings)
+   - 5.8 [No Decorative Sound](#58-no-decorative-sound)
+   - 5.9 [Informative Not Punishing Sound](#59-informative-not-punishing-sound)
+   - 5.10 [Preload Audio Files](#510-preload-audio-files)
+   - 5.11 [Subtle Default Volume](#511-subtle-default-volume)
+   - 5.12 [Reset currentTime Before Replay](#512-reset-currenttime-before-replay)
+   - 5.13 [Match Sound Weight to Action](#513-match-sound-weight-to-action)
+   - 5.14 [Sound Duration Matches Action Duration](#514-sound-duration-matches-action-duration)
+6. [Sound Synthesis](#6-sound-synthesis) — **MEDIUM**
+   - 6.1 [Reuse Single AudioContext](#61-reuse-single-audiocontext)
+   - 6.2 [Resume Suspended AudioContext](#62-resume-suspended-audiocontext)
+   - 6.3 [Clean Up Audio Nodes After Playback](#63-clean-up-audio-nodes-after-playback)
+   - 6.4 [Exponential Decay for Natural Sound](#64-exponential-decay-for-natural-sound)
+   - 6.5 [No Zero Target for Exponential Ramps](#65-no-zero-target-for-exponential-ramps)
+   - 6.6 [Set Initial Value Before Ramp](#66-set-initial-value-before-ramp)
+   - 6.7 [Noise for Percussive Sounds](#67-noise-for-percussive-sounds)
+   - 6.8 [Oscillators for Tonal Sounds](#68-oscillators-for-tonal-sounds)
+   - 6.9 [Bandpass Filter for Sound Character](#69-bandpass-filter-for-sound-character)
+   - 6.10 [Click Duration 5-15ms](#610-click-duration-5-15ms)
+   - 6.11 [Click Filter 3000-6000Hz](#611-click-filter-3000-6000hz)
+   - 6.12 [Gain Under 1.0](#612-gain-under-10)
+   - 6.13 [Filter Q Value 2-5](#613-filter-q-value-2-5)
+7. [Morphing Icons](#7-morphing-icons) — **LOW**
+   - 7.1 [Icons Must Use Exactly Three Lines](#71-icons-must-use-exactly-three-lines)
+   - 7.2 [Use Collapsed Constant for Unused Lines](#72-use-collapsed-constant-for-unused-lines)
+   - 7.3 [Consistent ViewBox Size](#73-consistent-viewbox-size)
+   - 7.4 [Shared Group for Rotational Variants](#74-shared-group-for-rotational-variants)
+   - 7.5 [Spring Physics for Rotation](#75-spring-physics-for-rotation)
+   - 7.6 [Reduced Motion Support for Icons](#76-reduced-motion-support-for-icons)
+   - 7.7 [Instant Jump for Non-Grouped Icons](#77-instant-jump-for-non-grouped-icons)
+   - 7.8 [Round Stroke Line Caps](#78-round-stroke-line-caps)
+   - 7.9 [Aria Hidden on Icon SVGs](#79-aria-hidden-on-icon-svgs)
+8. [Container Animation](#8-container-animation) — **MEDIUM**
+   - 8.1 [Two-Div Pattern for Animated Bounds](#81-two-div-pattern-for-animated-bounds)
+   - 8.2 [Guard Against Zero on Initial Render](#82-guard-against-zero-on-initial-render)
+   - 8.3 [Use ResizeObserver for Measurement](#83-use-resizeobserver-for-measurement)
+   - 8.4 [Overflow Hidden on Animated Container](#84-overflow-hidden-on-animated-container)
+   - 8.5 [Use Animated Bounds Sparingly](#85-use-animated-bounds-sparingly)
+   - 8.6 [Use Callback Ref for Measurement](#86-use-callback-ref-for-measurement)
+   - 8.7 [Add Delay for Natural Container Transitions](#87-add-delay-for-natural-container-transitions)
+9. [Laws of UX](#9-laws-of-ux) — **HIGH**
+   - 9.1 [Size Interactive Targets for Easy Clicking](#91-size-interactive-targets-for-easy-clicking)
+   - 9.2 [Expand Hit Areas with Invisible Padding](#92-expand-hit-areas-with-invisible-padding)
+   - 9.3 [Minimize Choices to Reduce Decision Time](#93-minimize-choices-to-reduce-decision-time)
+   - 9.4 [Chunk Data into Groups of 5-9](#94-chunk-data-into-groups-of-5-9)
+   - 9.5 [Respond Within 400ms](#95-respond-within-400ms)
+   - 9.6 [Fake Speed When Actual Speed Isn't Possible](#96-fake-speed-when-actual-speed-isnt-possible)
+   - 9.7 [Accept Messy Input, Output Clean Data](#97-accept-messy-input-output-clean-data)
+   - 9.8 [Show What Matters Now, Reveal Complexity Later](#98-show-what-matters-now-reveal-complexity-later)
+   - 9.9 [Use Familiar UI Patterns](#99-use-familiar-ui-patterns)
+   - 9.10 [Visual Polish Increases Perceived Usability](#910-visual-polish-increases-perceived-usability)
+   - 9.11 [Group Related Elements Spatially](#911-group-related-elements-spatially)
+   - 9.12 [Similar Elements Should Look Alike](#912-similar-elements-should-look-alike)
+   - 9.13 [Use Boundaries to Group Related Content](#913-use-boundaries-to-group-related-content)
+   - 9.14 [Make Important Elements Visually Distinct](#914-make-important-elements-visually-distinct)
+   - 9.15 [Place Key Items First or Last](#915-place-key-items-first-or-last)
+   - 9.16 [End Experiences with Clear Success States](#916-end-experiences-with-clear-success-states)
+   - 9.17 [Move Complexity to the System](#917-move-complexity-to-the-system)
+   - 9.18 [Show Progress Toward Completion](#918-show-progress-toward-completion)
+   - 9.19 [Show Incomplete State to Drive Completion](#919-show-incomplete-state-to-drive-completion)
+   - 9.20 [Simplify Complex Visuals into Clear Forms](#920-simplify-complex-visuals-into-clear-forms)
+   - 9.21 [Prioritize the Critical 20% of Features](#921-prioritize-the-critical-20-of-features)
+   - 9.22 [Minimize Extraneous Cognitive Load](#922-minimize-extraneous-cognitive-load)
+   - 9.23 [Visually Connect Related Elements](#923-visually-connect-related-elements)
+10. [Predictive Prefetching](#10-predictive-prefetching) — **MEDIUM**
+    - 10.1 [Trajectory Prediction Over Hover Prefetching](#101-trajectory-prediction-over-hover-prefetching)
+    - 10.2 [Prefetch by Intent, Not Viewport](#102-prefetch-by-intent-not-viewport)
+    - 10.3 [Use hitSlop to Trigger Predictions Earlier](#103-use-hitslop-to-trigger-predictions-earlier)
+    - 10.4 [Fall Back Gracefully on Touch Devices](#104-fall-back-gracefully-on-touch-devices)
+    - 10.5 [Prefetch on Keyboard Navigation](#105-prefetch-on-keyboard-navigation)
+    - 10.6 [Use Predictive Prefetching Selectively](#106-use-predictive-prefetching-selectively)
+11. [Typography](#11-typography) — **MEDIUM**
+    - 11.1 [Tabular Numbers for Data Display](#111-tabular-numbers-for-data-display)
+    - 11.2 [Oldstyle Numbers for Body Text](#112-oldstyle-numbers-for-body-text)
+    - 11.3 [Slashed Zero for Disambiguation](#113-slashed-zero-for-disambiguation)
+    - 11.4 [Enable Contextual Alternates](#114-enable-contextual-alternates)
+    - 11.5 [Use Disambiguation Stylistic Set for UI](#115-use-disambiguation-stylistic-set-for-ui)
+    - 11.6 [Keep Optical Sizing Auto](#116-keep-optical-sizing-auto)
+    - 11.7 [Use Antialiased Font Smoothing](#117-use-antialiased-font-smoothing)
+    - 11.8 [Balance Headings with text-wrap](#118-balance-headings-with-text-wrap)
+    - 11.9 [Offset Underlines from Descenders](#119-offset-underlines-from-descenders)
+    - 11.10 [Disable Font Synthesis for Missing Styles](#1110-disable-font-synthesis-for-missing-styles)
+    - 11.11 [Use font-display swap](#1111-use-font-display-swap)
+    - 11.12 [Continuous Weight Values with Variable Fonts](#1112-continuous-weight-values-with-variable-fonts)
+    - 11.13 [text-wrap pretty for Body Text](#1113-text-wrap-pretty-for-body-text)
+    - 11.14 [Pair Justified Text with Hyphens](#1114-pair-justified-text-with-hyphens)
+    - 11.15 [Add Letter Spacing to Uppercase Text](#1115-add-letter-spacing-to-uppercase-text)
+    - 11.16 [Use Typographic Fractions](#1116-use-typographic-fractions)
+12. [Visual Design](#12-visual-design) — **HIGH**
+    - 12.1 [Concentric Border Radius for Nested Elements](#121-concentric-border-radius-for-nested-elements)
+    - 12.2 [Layer Multiple Shadows for Realistic Depth](#122-layer-multiple-shadows-for-realistic-depth)
+    - 12.3 [Consistent Shadow Direction Across UI](#123-consistent-shadow-direction-across-ui)
+    - 12.4 [Use Neutral Colors for Shadows](#124-use-neutral-colors-for-shadows)
+    - 12.5 [Shadow Size Indicates Elevation](#125-shadow-size-indicates-elevation)
+    - 12.6 [Animate Shadows via Pseudo-Element Opacity](#126-animate-shadows-via-pseudo-element-opacity)
+    - 12.7 [Use a Consistent Spacing Scale](#127-use-a-consistent-spacing-scale)
+    - 12.8 [Use Semi-Transparent Borders](#128-use-semi-transparent-borders)
+    - 12.9 [Full Shadow Anatomy on Buttons](#129-full-shadow-anatomy-on-buttons)
+
+---
+
+## 1. Animation Principles
+
+**Impact:** CRITICAL — Disney's 12 principles adapted for web. Violations here produce the most noticeable quality issues.
+
+### 1.1 User Animations Under 300ms
+
+User-initiated animations must complete within 300ms.
+
+**Incorrect (exceeds 300ms limit):**
+
+```css
+.button { transition: transform 400ms; }
+```
+
+**Correct (within 300ms):**
+
+```css
+.button { transition: transform 200ms; }
+```
+
+### 1.2 Consistent Timing for Similar Elements
+
+Similar elements must use identical timing values.
+
+**Incorrect (inconsistent timing):**
+
+```css
+.button-primary { transition: 200ms; }
+.button-secondary { transition: 150ms; }
+```
+
+**Correct (consistent timing):**
+
+```css
+.button-primary { transition: 200ms; }
+.button-secondary { transition: 200ms; }
+```
+
+### 1.3 No Entrance Animation on Context Menus
+
+Context menus should not animate on entrance (exit only).
+
+**Incorrect (animates entrance):**
+
+```tsx
+<motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} />
+```
+
+**Correct (exit only):**
+
+```tsx
+<motion.div exit={{ opacity: 0 }} />
+```
+
+### 1.4 Exponential Ramps for Natural Decay
+
+Use exponential ramps, not linear, for natural decay.
+
+**Incorrect (linear ramp):**
+
+```ts
+gain.gain.linearRampToValueAtTime(0, t + 0.05);
+```
+
+**Correct (exponential ramp):**
+
+```ts
+gain.gain.exponentialRampToValueAtTime(0.001, t + 0.05);
+```
+
+### 1.5 No Linear Easing for Motion
+
+Linear easing should only be used for progress indicators, not motion.
+
+**Incorrect (linear for motion):**
+
+```css
+.card { transition: transform 200ms linear; }
+```
+
+**Correct (linear for progress only):**
+
+```css
+.progress-bar { transition: width 100ms linear; }
+```
+
+### 1.6 Active State Scale Transform
+
+Interactive elements must have active/pressed state with scale transform.
+
+**Incorrect (no active state):**
+
+```css
+.button:hover { background: var(--gray-3); }
+/* Missing :active state */
+```
+
+**Correct (active state present):**
+
+```css
+.button:active { transform: scale(0.98); }
+```
+
+### 1.7 Subtle Squash and Stretch
+
+Squash/stretch deformation must be subtle (0.95-1.05 range).
+
+**Incorrect (excessive deformation):**
+
+```tsx
+<motion.div whileTap={{ scale: 0.8 }} />
+```
+
+**Correct (subtle deformation):**
+
+```tsx
+<motion.div whileTap={{ scale: 0.98 }} />
+```
+
+### 1.8 Springs for Overshoot and Settle
+
+Use springs (not easing) when overshoot-and-settle is needed.
+
+**Incorrect (easing for bounce):**
+
+```tsx
+<motion.div transition={{ duration: 0.3, ease: "easeOut" }} />
+```
+
+**Correct (spring physics):**
+
+```tsx
+<motion.div transition={{ type: "spring", stiffness: 500, damping: 30 }} />
+```
+
+### 1.9 Stagger Under 50ms Per Item
+
+Stagger delays must not exceed 50ms per item.
+
+**Incorrect (excessive stagger):**
+
+```tsx
+transition={{ staggerChildren: 0.15 }}
+```
+
+**Correct (reasonable stagger):**
+
+```tsx
+transition={{ staggerChildren: 0.03 }}
+```
+
+### 1.10 Single Focal Point
+
+Only one element should animate prominently at a time.
+
+**Incorrect (competing animations):**
+
+```tsx
+<motion.div animate={{ scale: 1.1 }} />
+<motion.div animate={{ scale: 1.1 }} />
+```
+
+### 1.11 Dim Background for Focus
+
+Modal/dialog backgrounds should dim to direct focus.
+
+**Incorrect (transparent overlay):**
+
+```css
+.overlay { background: transparent; }
+```
+
+**Correct (dimmed overlay):**
+
+```css
+.overlay { background: var(--black-a6); }
+```
+
+### 1.12 Z-Index Layering for Animated Elements
+
+Animated elements must respect z-index layering.
+
+**Incorrect (no z-index):**
+
+```css
+.tooltip { /* No z-index, may render behind other elements */ }
+```
+
+**Correct (explicit z-index):**
+
+```css
+.tooltip { z-index: 50; }
+```
+
+---
+
+## 2. Timing Functions
+
+**Impact:** HIGH — Choosing the right timing function based on whether motion is user-driven, system-driven, or high-frequency.
+
+**Decision framework:** Is this motion reacting to the user, or is the system speaking?
+
+| Motion Type | Best Choice | Why |
+|-------------|-------------|-----|
+| User-driven (drag, flick, gesture) | Spring | Survives interruption, preserves velocity |
+| System-driven (state change, feedback) | Easing | Clear start/end, predictable timing |
+| Time representation (progress, loading) | Linear | 1:1 relationship between time and progress |
+| High-frequency (typing, fast toggles) | None | Animation adds noise, feels slower |
+
+### 2.1 Springs for Gesture-Driven Motion
+
+Gesture-driven motion (drag, flick, swipe) must use springs.
+
+**Incorrect (easing for drag):**
+
+```tsx
+<motion.div
+  drag="x"
+  transition={{ duration: 0.3, ease: "easeOut" }}
+/>
+```
+
+**Correct (spring for drag):**
+
+```tsx
+<motion.div
+  drag="x"
+  transition={{ type: "spring", stiffness: 500, damping: 30 }}
+/>
+```
+
+### 2.2 Springs for Interruptible Motion
+
+Motion that can be interrupted must use springs.
+
+**Incorrect (easing for interruptible):**
+
+```tsx
+<motion.div
+  animate={{ x: isOpen ? 200 : 0 }}
+  transition={{ duration: 0.3 }}
+/>
+```
+
+**Correct (spring for interruptible):**
+
+```tsx
+<motion.div
+  animate={{ x: isOpen ? 200 : 0 }}
+  transition={{ type: "spring", stiffness: 400, damping: 25 }}
+/>
+```
+
+### 2.3 Springs Preserve Input Velocity
+
+When velocity matters, use springs to preserve input energy.
+
+**Incorrect (velocity ignored):**
+
+```tsx
+onDragEnd={(e, info) => {
+  animate(target, { x: 0 }, { duration: 0.3 });
+}}
+```
+
+**Correct (velocity preserved):**
+
+```tsx
+onDragEnd={(e, info) => {
+  animate(target, { x: 0 }, {
+    type: "spring",
+    velocity: info.velocity.x,
+  });
+}}
+```
+
+### 2.4 Balanced Spring Parameters
+
+Spring parameters must be balanced; avoid excessive oscillation.
+
+**Incorrect (too bouncy):**
+
+```tsx
+transition={{
+  type: "spring",
+  stiffness: 1000,
+  damping: 5,
+}}
+```
+
+**Correct (balanced):**
+
+```tsx
+transition={{
+  type: "spring",
+  stiffness: 500,
+  damping: 30,
+}}
+```
+
+### 2.5 Easing for System State Changes
+
+System-initiated state changes should use easing curves.
+
+**Incorrect (spring for announcement):**
+
+```tsx
+<motion.div
+  animate={{ y: 0 }}
+  transition={{ type: "spring" }}
+/>
+```
+
+**Correct (easing for announcement):**
+
+```tsx
+<motion.div
+  animate={{ y: 0 }}
+  transition={{ duration: 0.2, ease: "easeOut" }}
+/>
+```
+
+### 2.6 Ease-Out for Entrances
+
+Entrances must use ease-out (arrive fast, settle gently).
+
+**Incorrect (ease-in for entrance):**
+
+```css
+.modal-enter { animation-timing-function: ease-in; }
+```
+
+**Correct (ease-out for entrance):**
+
+```css
+.modal-enter { animation-timing-function: ease-out; }
+```
+
+### 2.7 Ease-In for Exits
+
+Exits must use ease-in (build momentum before departure).
+
+**Incorrect (ease-out for exit):**
+
+```css
+.modal-exit { animation-timing-function: ease-out; }
+```
+
+**Correct (ease-in for exit):**
+
+```css
+.modal-exit { animation-timing-function: ease-in; }
+```
+
+### 2.8 Ease-In-Out for View Transitions
+
+View/mode transitions use ease-in-out for neutral attention.
+
+**Correct:**
+
+```css
+.page-transition { animation-timing-function: ease-in-out; }
+```
+
+### 2.9 Linear Easing Only for Progress
+
+Linear easing only for progress bars and time representation.
+
+**Incorrect (linear for motion):**
+
+```css
+.card-slide { transition: transform 200ms linear; }
+```
+
+**Correct (linear for progress):**
+
+```css
+.progress-bar { transition: width 100ms linear; }
+```
+
+### 2.10 Press and Hover 120-180ms
+
+Press and hover interactions should use 120-180ms duration.
+
+**Incorrect (too slow):**
+
+```css
+.button:hover { transition: background-color 400ms; }
+```
+
+**Correct (appropriate duration):**
+
+```css
+.button:hover { transition: background-color 150ms; }
+```
+
+### 2.11 Small State Changes 180-260ms
+
+Small state changes should use 180-260ms duration.
+
+**Correct:**
+
+```css
+.toggle { transition: transform 200ms ease; }
+```
+
+### 2.12 Max 300ms for User Actions
+
+User-initiated animations must not exceed 300ms.
+
+**Incorrect (exceeds limit):**
+
+```tsx
+<motion.div transition={{ duration: 0.5 }} />
+```
+
+**Correct (within limit):**
+
+```tsx
+<motion.div transition={{ duration: 0.25 }} />
+```
+
+### 2.13 Shorten Duration Before Adjusting Curve
+
+If animation feels slow, shorten duration before adjusting curve.
+
+**Incorrect (adjusting curve instead):**
+
+```css
+.element { transition: 400ms cubic-bezier(0, 0.9, 0.1, 1); }
+```
+
+**Correct (shorter duration):**
+
+```css
+.element { transition: 200ms ease-out; }
+```
+
+### 2.14 No Animation for High-Frequency Interactions
+
+High-frequency interactions should have no animation.
+
+**Incorrect (animated on every keystroke):**
+
+```tsx
+function SearchInput() {
+  return (
+    <motion.div animate={{ scale: [1, 1.02, 1] }}>
+      <input onChange={handleSearch} />
+    </motion.div>
+  );
+}
+```
+
+**Correct (no animation):**
+
+```tsx
+function SearchInput() {
+  return <input onChange={handleSearch} />;
+}
+```
+
+### 2.15 No Animation for Keyboard Navigation
+
+Keyboard navigation should be instant, no animation.
+
+**Incorrect (animated focus):**
+
+```tsx
+function Menu() {
+  return items.map(item => (
+    <motion.li
+      whileFocus={{ scale: 1.05 }}
+      transition={{ duration: 0.2 }}
+    />
+  ));
+}
+```
+
+**Correct (CSS focus-visible only):**
+
+```tsx
+function Menu() {
+  return items.map(item => (
+    <li className={styles.menuItem} />
+  ));
+}
+```
+
+### 2.16 No Entrance Animation for Context Menus
+
+Context menus should not animate on entrance (exit only).
+
+**Incorrect (entrance animation):**
+
+```tsx
+<motion.div
+  initial={{ opacity: 0, scale: 0.95 }}
+  animate={{ opacity: 1, scale: 1 }}
+  exit={{ opacity: 0 }}
+/>
+```
+
+**Correct (exit only):**
+
+```tsx
+<motion.div exit={{ opacity: 0, scale: 0.95 }} />
+```
+
+**Quick reference:**
+
+| Interaction | Timing | Type |
+|-------------|--------|------|
+| Drag release | Spring | `stiffness: 500, damping: 30` |
+| Button press | 150ms | `ease` |
+| Modal enter | 200ms | `ease-out` |
+| Modal exit | 150ms | `ease-in` |
+| Page transition | 250ms | `ease-in-out` |
+| Progress bar | varies | `linear` |
+| Typing feedback | 0ms | none |
+
+---
+
+## 3. Exit Animations
+
+**Impact:** HIGH — Correct AnimatePresence usage prevents layout shifts, stale interactions, and orphaned elements.
+
+### 3.1 AnimatePresence Wrapper Required
+
+Conditional motion elements must be wrapped in AnimatePresence.
+
+**Incorrect (no wrapper):**
+
+```tsx
+{isVisible && (
+  <motion.div exit={{ opacity: 0 }} />
+)}
+```
+
+**Correct (wrapped):**
+
+```tsx
+<AnimatePresence>
+  {isVisible && (
+    <motion.div exit={{ opacity: 0 }} />
+  )}
+</AnimatePresence>
+```
+
+### 3.2 Exit Prop Required Inside AnimatePresence
+
+Elements inside AnimatePresence should have exit prop defined.
+
+**Incorrect (missing exit):**
+
+```tsx
+<AnimatePresence>
+  {isOpen && (
+    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} />
+  )}
+</AnimatePresence>
+```
+
+**Correct (exit defined):**
+
+```tsx
+<AnimatePresence>
+  {isOpen && (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+    />
+  )}
+</AnimatePresence>
+```
+
+### 3.3 Unique Keys in AnimatePresence Lists
+
+Dynamic lists inside AnimatePresence must have unique keys.
+
+**Incorrect (index as key):**
+
+```tsx
+<AnimatePresence>
+  {items.map((item, index) => (
+    <motion.div key={index} exit={{ opacity: 0 }} />
+  ))}
+</AnimatePresence>
+```
+
+**Correct (stable unique key):**
+
+```tsx
+<AnimatePresence>
+  {items.map((item) => (
+    <motion.div key={item.id} exit={{ opacity: 0 }} />
+  ))}
+</AnimatePresence>
+```
+
+### 3.4 Exit Mirrors Initial for Symmetry
+
+Exit animation should mirror initial for symmetry.
+
+**Incorrect (asymmetric exit):**
+
+```tsx
+<motion.div
+  initial={{ opacity: 0, y: 20 }}
+  animate={{ opacity: 1, y: 0 }}
+  exit={{ scale: 0 }}
+/>
+```
+
+**Correct (symmetric exit):**
+
+```tsx
+<motion.div
+  initial={{ opacity: 0, y: 20 }}
+  animate={{ opacity: 1, y: 0 }}
+  exit={{ opacity: 0, y: 20 }}
+/>
+```
+
+### 3.5 useIsPresent in Child Component
+
+useIsPresent must be called from child of AnimatePresence, not parent.
+
+**Incorrect (hook in parent):**
+
+```tsx
+function Parent() {
+  const isPresent = useIsPresent();
+  return (
+    <AnimatePresence>
+      {show && <Child />}
+    </AnimatePresence>
+  );
+}
+```
+
+**Correct (hook in child):**
+
+```tsx
+function Child() {
+  const isPresent = useIsPresent();
+  return <motion.div data-exiting={!isPresent} />;
+}
+```
+
+### 3.6 Call safeToRemove After Async Work
+
+When using usePresence, always call safeToRemove after async work.
+
+**Incorrect (missing safeToRemove):**
+
+```tsx
+function AsyncComponent() {
+  const [isPresent, safeToRemove] = usePresence();
+
+  useEffect(() => {
+    if (!isPresent) {
+      cleanup();
+    }
+  }, [isPresent]);
+}
+```
+
+**Correct (safeToRemove called):**
+
+```tsx
+function AsyncComponent() {
+  const [isPresent, safeToRemove] = usePresence();
+
+  useEffect(() => {
+    if (!isPresent) {
+      cleanup().then(safeToRemove);
+    }
+  }, [isPresent, safeToRemove]);
+}
+```
+
+### 3.7 Disable Interactions on Exiting Elements
+
+Disable interactions on exiting elements using isPresent.
+
+**Incorrect (clickable during exit):**
+
+```tsx
+function Card() {
+  const isPresent = useIsPresent();
+  return <button onClick={handleClick}>Click</button>;
+}
+```
+
+**Correct (disabled during exit):**
+
+```tsx
+function Card() {
+  const isPresent = useIsPresent();
+  return (
+    <button onClick={handleClick} disabled={!isPresent}>
+      Click
+    </button>
+  );
+}
+```
+
+### 3.8 Mode "wait" Doubles Duration
+
+Mode "wait" nearly doubles animation duration; adjust timing accordingly.
+
+**Incorrect (too slow with wait):**
+
+```tsx
+<AnimatePresence mode="wait">
+  <motion.div transition={{ duration: 0.3 }} />
+</AnimatePresence>
+```
+
+**Correct (halved timing):**
+
+```tsx
+<AnimatePresence mode="wait">
+  <motion.div transition={{ duration: 0.15 }} />
+</AnimatePresence>
+```
+
+### 3.9 Mode "sync" Causes Layout Conflicts
+
+Mode "sync" causes layout conflicts; position exiting elements absolutely.
+
+**Incorrect (sync with layout competition):**
+
+```tsx
+<AnimatePresence mode="sync">
+  {items.map(item => (
+    <motion.div exit={{ opacity: 0 }}>{item}</motion.div>
+  ))}
+</AnimatePresence>
+```
+
+**Correct (popLayout instead):**
+
+```tsx
+<AnimatePresence mode="popLayout">
+  {items.map(item => (
+    <motion.div exit={{ opacity: 0 }}>{item}</motion.div>
+  ))}
+</AnimatePresence>
+```
+
+### 3.10 popLayout for List Reordering
+
+Use popLayout mode for list reordering animations.
+
+**Incorrect (default mode causes shifts):**
+
+```tsx
+<AnimatePresence>
+  {items.map(item => <ListItem key={item.id} />)}
+</AnimatePresence>
+```
+
+**Correct (popLayout prevents shifts):**
+
+```tsx
+<AnimatePresence mode="popLayout">
+  {items.map(item => <ListItem key={item.id} />)}
+</AnimatePresence>
+```
+
+### 3.11 Propagate Prop for Nested AnimatePresence
+
+Nested AnimatePresence must use propagate prop for coordinated exits.
+
+**Incorrect (children vanish instantly):**
+
+```tsx
+<AnimatePresence>
+  {isOpen && (
+    <motion.div exit={{ opacity: 0 }}>
+      <AnimatePresence>
+        {items.map(item => (
+          <motion.div key={item.id} exit={{ scale: 0 }} />
+        ))}
+      </AnimatePresence>
+    </motion.div>
+  )}
+</AnimatePresence>
+```
+
+**Correct (propagate on both):**
+
+```tsx
+<AnimatePresence propagate>
+  {isOpen && (
+    <motion.div exit={{ opacity: 0 }}>
+      <AnimatePresence propagate>
+        {items.map(item => (
+          <motion.div key={item.id} exit={{ scale: 0 }} />
+        ))}
+      </AnimatePresence>
+    </motion.div>
+  )}
+</AnimatePresence>
+```
+
+### 3.12 Coordinated Parent-Child Exit Timing
+
+Parent and child exit durations should be coordinated.
+
+**Incorrect (parent too fast):**
+
+```tsx
+<motion.div exit={{ opacity: 0 }} transition={{ duration: 0.1 }}>
+  <motion.div exit={{ scale: 0 }} transition={{ duration: 0.5 }} />
+</motion.div>
+```
+
+**Correct (coordinated timing):**
+
+```tsx
+<motion.div exit={{ opacity: 0 }} transition={{ duration: 0.2 }}>
+  <motion.div exit={{ scale: 0 }} transition={{ duration: 0.15 }} />
+</motion.div>
+```
+
+Reference: [Motion AnimatePresence Documentation](https://motion.dev/docs/react-animate-presence)
+
+---
+
+## 4. CSS Pseudo Elements
+
+**Impact:** MEDIUM — Leveraging pseudo-elements and View Transitions to reduce DOM nodes and improve transitions.
+
+### 4.1 Content Property Required for Pseudo-Elements
+
+::before and ::after require content property to render.
+
+**Incorrect (missing content):**
+
+```css
+.button::before {
+  position: absolute;
+  background: var(--gray-3);
+}
+```
+
+**Correct (content set):**
+
+```css
+.button::before {
+  content: "";
+  position: absolute;
+  background: var(--gray-3);
+}
+```
+
+### 4.2 Pseudo-Elements Over DOM Nodes
+
+Use pseudo-elements for decorative content instead of extra DOM nodes.
+
+**Incorrect (extra DOM node):**
+
+```tsx
+<button className={styles.button}>
+  <span className={styles.background} />
+  Click me
+</button>
+```
+
+**Correct (pseudo-element):**
+
+```tsx
+<button className={styles.button}>
+  Click me
+</button>
+```
+
+```css
+.button::before {
+  content: "";
+  /* decorative background */
+}
+```
+
+### 4.3 Position Relative Parent for Pseudo-Elements
+
+Parent must have position: relative for absolute pseudo-elements.
+
+**Incorrect (no position on parent):**
+
+```css
+.button::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+}
+/* .button has no position */
+```
+
+**Correct (parent positioned):**
+
+```css
+.button {
+  position: relative;
+}
+
+.button::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+}
+```
+
+### 4.4 Z-Index Layering for Pseudo-Elements
+
+Pseudo-elements need z-index to layer correctly with content.
+
+**Incorrect (covers button text):**
+
+```css
+.button::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--gray-3);
+}
+```
+
+**Correct (layered behind):**
+
+```css
+.button {
+  position: relative;
+  z-index: 1;
+}
+
+.button::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--gray-3);
+  z-index: -1;
+}
+```
+
+### 4.5 Hit Target Expansion with Pseudo-Elements
+
+Use negative inset values to expand hit targets without extra markup.
+
+**Incorrect (wrapper for hit target):**
+
+```tsx
+<div className={styles.wrapper}>
+  <a className={styles.link}>Link</a>
+</div>
+```
+
+**Correct (pseudo-element expansion):**
+
+```css
+.link {
+  position: relative;
+}
+
+.link::before {
+  content: "";
+  position: absolute;
+  inset: -8px -12px;
+}
+```
+
+### 4.6 View Transition Name Required
+
+Elements participating in view transitions need view-transition-name.
+
+**Incorrect (no transition name):**
+
+```ts
+document.startViewTransition(() => {
+  targetImg.src = newSrc;
+});
+```
+
+**Correct (transition name assigned):**
+
+```ts
+sourceImg.style.viewTransitionName = "card";
+document.startViewTransition(() => {
+  sourceImg.style.viewTransitionName = "";
+  targetImg.style.viewTransitionName = "card";
+});
+```
+
+### 4.7 Unique View Transition Names
+
+Each view-transition-name must be unique on the page during transition.
+
+**Incorrect (duplicate names):**
+
+```css
+.card {
+  view-transition-name: card;
+}
+/* Multiple cards with same name */
+```
+
+**Correct (unique per element):**
+
+```ts
+element.style.viewTransitionName = `card-${id}`;
+```
+
+### 4.8 Clean Up View Transition Names
+
+Remove view-transition-name after transition completes.
+
+**Incorrect (stale name):**
+
+```ts
+sourceImg.style.viewTransitionName = "card";
+document.startViewTransition(() => {
+  targetImg.style.viewTransitionName = "card";
+});
+```
+
+**Correct (name cleaned up):**
+
+```ts
+sourceImg.style.viewTransitionName = "card";
+document.startViewTransition(() => {
+  sourceImg.style.viewTransitionName = "";
+  targetImg.style.viewTransitionName = "card";
+});
+```
+
+### 4.9 View Transitions Over JS Libraries
+
+Prefer View Transitions API over JavaScript animation libraries for page transitions.
+
+**Incorrect (JS-based transition):**
+
+```tsx
+import { motion } from "motion/react";
+
+function ImageLightbox() {
+  return (
+    <motion.img layoutId="hero" />
+  );
+}
+```
+
+**Correct (native View Transition):**
+
+```ts
+function openLightbox(img: HTMLImageElement) {
+  img.style.viewTransitionName = "hero";
+  document.startViewTransition(() => {
+    // Native browser transition
+  });
+}
+```
+
+### 4.10 Style View Transition Pseudo-Elements
+
+Style view transition pseudo-elements for custom animations.
+
+**Incorrect (default crossfade only):**
+
+```ts
+document.startViewTransition(() => { /* ... */ });
+```
+
+**Correct (custom animation):**
+
+```css
+::view-transition-group(card) {
+  animation-duration: 300ms;
+  animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
+}
+```
+
+### 4.11 Use ::backdrop for Dialog Backgrounds
+
+Use ::backdrop pseudo-element for dialog/popover backgrounds.
+
+**Incorrect (extra overlay node):**
+
+```tsx
+<>
+  <div className={styles.overlay} onClick={close} />
+  <dialog className={styles.dialog}>{children}</dialog>
+</>
+```
+
+**Correct (native ::backdrop):**
+
+```css
+dialog::backdrop {
+  background: var(--black-a6);
+  backdrop-filter: blur(4px);
+}
+```
+
+### 4.12 Use ::placeholder for Input Styling
+
+Use ::placeholder for input placeholder styling, not wrapper elements.
+
+**Incorrect (custom placeholder node):**
+
+```tsx
+<div className={styles.inputWrapper}>
+  {!value && <span className={styles.placeholder}>Enter text...</span>}
+  <input value={value} />
+</div>
+```
+
+**Correct (native ::placeholder):**
+
+```css
+input::placeholder {
+  color: var(--gray-9);
+  opacity: 1;
+}
+```
+
+### 4.13 Use ::selection for Text Styling
+
+Use ::selection for text selection styling.
+
+**Correct:**
+
+```css
+::selection {
+  background: var(--blue-a5);
+  color: var(--gray-12);
+}
+```
+
+### 4.14 Use ::marker for Custom List Bullets
+
+Use ::marker to style list bullets without extra elements or background-image hacks.
+
+**Incorrect (background image hack):**
+
+```css
+li {
+  list-style: none;
+  background: url("bullet.svg") no-repeat 0 4px;
+  padding-left: 20px;
+}
+```
+
+**Correct (native ::marker):**
+
+```css
+li::marker {
+  color: var(--gray-8);
+  font-size: 0.8em;
+}
+```
+
+### 4.15 Use ::first-line for Typographic Treatments
+
+Use ::first-line for drop-cap-adjacent styling without JavaScript or hardcoded spans.
+
+**Incorrect (manual span):**
+
+```tsx
+<p>
+  <span className={styles["first-line"]}>The opening line</span>
+  is styled differently from the rest.
+</p>
+```
+
+**Correct (native ::first-line):**
+
+```css
+.article p:first-of-type::first-line {
+  font-variant-caps: small-caps;
+  font-weight: var(--font-weight-medium);
+}
+```
+
+Reference: [MDN Pseudo-elements Reference](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-elements), [View Transitions API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API)
+
+---
+
+## 5. Audio Feedback
+
+**Impact:** MEDIUM — When and how to use sound in UI, covering accessibility, appropriateness, and implementation.
+
+### 5.1 Visual Equivalent for Every Sound
+
+Every audio cue must have a visual equivalent; sound never replaces visual feedback.
+
+**Incorrect (sound without visual):**
+
+```tsx
+function SubmitButton({ onClick }) {
+  const handleClick = () => {
+    playSound("success");
+    onClick();
+  };
+}
+```
+
+**Correct (sound with visual):**
+
+```tsx
+function SubmitButton({ onClick }) {
+  const [status, setStatus] = useState("idle");
+
+  const handleClick = () => {
+    playSound("success");
+    setStatus("success");
+    onClick();
+  };
+
+  return <button data-status={status}>Submit</button>;
+}
+```
+
+### 5.2 Toggle Setting to Disable Sounds
+
+Provide explicit toggle to disable sounds in settings.
+
+**Incorrect (no way to disable):**
+
+```tsx
+function App() {
+  return <SoundProvider>{children}</SoundProvider>;
+}
+```
+
+**Correct (toggle available):**
+
+```tsx
+function App() {
+  const { soundEnabled } = usePreferences();
+  return (
+    <SoundProvider enabled={soundEnabled}>
+      {children}
+    </SoundProvider>
+  );
+}
+```
+
+### 5.3 Respect prefers-reduced-motion for Sound
+
+Respect prefers-reduced-motion as proxy for sound sensitivity.
+
+**Incorrect (ignores preference):**
+
+```tsx
+function playSound(name: string) {
+  audio.play();
+}
+```
+
+**Correct (checks preference):**
+
+```tsx
+function playSound(name: string) {
+  const prefersReducedMotion = window.matchMedia(
+    "(prefers-reduced-motion: reduce)"
+  ).matches;
+
+  if (prefersReducedMotion) return;
+  audio.play();
+}
+```
+
+### 5.4 Independent Volume Control
+
+Allow volume adjustment independent of system volume.
+
+**Incorrect (always full volume):**
+
+```tsx
+function playSound() {
+  audio.volume = 1;
+  audio.play();
+}
+```
+
+**Correct (user-controlled volume):**
+
+```tsx
+function playSound() {
+  const { volume } = usePreferences();
+  audio.volume = volume;
+  audio.play();
+}
+```
+
+### 5.5 No Sound on High-Frequency Interactions
+
+Do not add sound to high-frequency interactions (typing, keyboard navigation).
+
+**Incorrect (sound on every keystroke):**
+
+```tsx
+function Input({ onChange }) {
+  const handleChange = (e) => {
+    playSound("keystroke");
+    onChange(e);
+  };
+}
+```
+
+**Correct (no sound on typing):**
+
+```tsx
+function Input({ onChange }) {
+  return <input onChange={onChange} />;
+}
+```
+
+### 5.6 Sound for Confirmations
+
+Sound is appropriate for confirmations: payments, uploads, form submissions.
+
+**Correct:**
+
+```tsx
+async function handlePayment() {
+  await processPayment();
+  playSound("success");
+  showConfirmation();
+}
+```
+
+### 5.7 Sound for Errors and Warnings
+
+Sound is appropriate for errors and warnings that can't be overlooked.
+
+**Correct:**
+
+```tsx
+function handleError(error: Error) {
+  playSound("error");
+  showErrorToast(error.message);
+}
+```
+
+### 5.8 No Decorative Sound
+
+Do not add sound to decorative moments with no informational value.
+
+**Incorrect (hover sound):**
+
+```tsx
+function Card({ onHover }) {
+  return (
+    <div onMouseEnter={() => playSound("hover")}>
+      {children}
+    </div>
+  );
+}
+```
+
+### 5.9 Informative Not Punishing Sound
+
+Sound should inform, not punish; avoid harsh sounds for user mistakes.
+
+**Incorrect (harsh buzzer):**
+
+```tsx
+function ValidationError() {
+  playSound("loud-buzzer");
+  return <span>Invalid input</span>;
+}
+```
+
+**Correct (gentle alert):**
+
+```tsx
+function ValidationError() {
+  playSound("gentle-alert");
+  return <span>Invalid input</span>;
+}
+```
+
+### 5.10 Preload Audio Files
+
+Preload audio files to avoid playback delay.
+
+**Incorrect (loads on demand):**
+
+```tsx
+function playSound(name: string) {
+  const audio = new Audio(`/sounds/${name}.mp3`);
+  audio.play();
+}
+```
+
+**Correct (preloaded):**
+
+```tsx
+const sounds = {
+  success: new Audio("/sounds/success.mp3"),
+  error: new Audio("/sounds/error.mp3"),
+};
+
+Object.values(sounds).forEach(audio => audio.load());
+
+function playSound(name: keyof typeof sounds) {
+  sounds[name].currentTime = 0;
+  sounds[name].play();
+}
+```
+
+### 5.11 Subtle Default Volume
+
+Default volume should be subtle, not loud.
+
+**Incorrect (too loud):**
+
+```tsx
+const DEFAULT_VOLUME = 1.0;
+```
+
+**Correct (subtle):**
+
+```tsx
+const DEFAULT_VOLUME = 0.3;
+```
+
+### 5.12 Reset currentTime Before Replay
+
+Reset audio currentTime before replay to allow rapid triggering.
+
+**Incorrect (won't replay if playing):**
+
+```tsx
+function playSound() {
+  audio.play();
+}
+```
+
+**Correct (reset before play):**
+
+```tsx
+function playSound() {
+  audio.currentTime = 0;
+  audio.play();
+}
+```
+
+### 5.13 Match Sound Weight to Action
+
+Sound weight should match action importance.
+
+**Incorrect (fanfare for toggle):**
+
+```tsx
+function handleToggle() {
+  playSound("triumphant-fanfare");
+  setEnabled(!enabled);
+}
+```
+
+**Correct (weight matches action):**
+
+```tsx
+function handleToggle() {
+  playSound("soft-click");
+  setEnabled(!enabled);
+}
+
+function handlePurchase() {
+  playSound("success-chime");
+  completePurchase();
+}
+```
+
+### 5.14 Sound Duration Matches Action Duration
+
+Sound duration should match action duration.
+
+**Incorrect (long sound for instant action):**
+
+```tsx
+function handleClick() {
+  playSound("long-whoosh"); // 2000ms
+}
+```
+
+**Correct (matched duration):**
+
+```tsx
+function handleClick() {
+  playSound("click"); // 50ms
+}
+
+function handleUpload() {
+  playSound("upload-progress"); // Matches upload duration
+}
+```
+
+**Sound appropriateness matrix:**
+
+| Interaction | Sound? | Reason |
+|-------------|--------|--------|
+| Payment success | Yes | Significant confirmation |
+| Form submission | Yes | User needs assurance |
+| Error state | Yes | Can't be overlooked |
+| Notification | Yes | May not be looking at screen |
+| Button click | Maybe | Only for significant buttons |
+| Typing | No | Too frequent |
+| Hover | No | Decorative only |
+| Scroll | No | Too frequent |
+| Navigation | No | Keyboard nav would be noisy |
+
+Reference: [Web Audio API Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API), [prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
+
+---
+
+## 6. Sound Synthesis
+
+**Impact:** MEDIUM — Web Audio API best practices for procedural sound generation.
+
+### 6.1 Reuse Single AudioContext
+
+Reuse a single AudioContext instance; do not create new ones per sound.
+
+**Incorrect (new context per call):**
+
+```ts
+function playSound() {
+  const ctx = new AudioContext();
+}
+```
+
+**Correct (singleton):**
+
+```ts
+let audioContext: AudioContext | null = null;
+
+function getAudioContext(): AudioContext {
+  if (!audioContext) {
+    audioContext = new AudioContext();
+  }
+  return audioContext;
+}
+```
+
+### 6.2 Resume Suspended AudioContext
+
+Check and resume suspended AudioContext before playing.
+
+**Incorrect (plays without checking):**
+
+```ts
+function playSound() {
+  const ctx = getAudioContext();
+}
+```
+
+**Correct (resumes if suspended):**
+
+```ts
+function playSound() {
+  const ctx = getAudioContext();
+  if (ctx.state === "suspended") {
+    ctx.resume();
+  }
+}
+```
+
+### 6.3 Clean Up Audio Nodes After Playback
+
+Disconnect and clean up audio nodes after playback.
+
+**Incorrect (nodes remain connected):**
+
+```ts
+source.start();
+```
+
+**Correct (cleaned up on end):**
+
+```ts
+source.start();
+source.onended = () => {
+  source.disconnect();
+  gain.disconnect();
+};
+```
+
+### 6.4 Exponential Decay for Natural Sound
+
+Use exponential ramps for natural decay, not linear.
+
+**Incorrect (linear ramp):**
+
+```ts
+gain.gain.linearRampToValueAtTime(0, t + 0.05);
+```
+
+**Correct (exponential ramp):**
+
+```ts
+gain.gain.exponentialRampToValueAtTime(0.001, t + 0.05);
+```
+
+### 6.5 No Zero Target for Exponential Ramps
+
+Exponential ramps cannot target 0; use 0.001 or similar small value.
+
+**Incorrect (targets zero):**
+
+```ts
+gain.gain.exponentialRampToValueAtTime(0, t + 0.05);
+```
+
+**Correct (targets near-zero):**
+
+```ts
+gain.gain.exponentialRampToValueAtTime(0.001, t + 0.05);
+```
+
+### 6.6 Set Initial Value Before Ramp
+
+Set initial value before ramping to avoid glitches.
+
+**Incorrect (no initial value):**
+
+```ts
+gain.gain.exponentialRampToValueAtTime(0.001, t + 0.05);
+```
+
+**Correct (initial value set):**
+
+```ts
+gain.gain.setValueAtTime(0.3, t);
+gain.gain.exponentialRampToValueAtTime(0.001, t + 0.05);
+```
+
+### 6.7 Noise for Percussive Sounds
+
+Use filtered noise for clicks/taps, not oscillators.
+
+**Incorrect (oscillator for click):**
+
+```ts
+const osc = ctx.createOscillator();
+osc.type = "sine";
+```
+
+**Correct (noise burst for click):**
+
+```ts
+const buffer = ctx.createBuffer(1, ctx.sampleRate * 0.008, ctx.sampleRate);
+const data = buffer.getChannelData(0);
+for (let i = 0; i < data.length; i++) {
+  data[i] = (Math.random() * 2 - 1) * Math.exp(-i / 50);
+}
+```
+
+### 6.8 Oscillators for Tonal Sounds
+
+Use oscillators with pitch movement for tonal sounds (pops, confirmations).
+
+**Incorrect (static frequency):**
+
+```ts
+osc.frequency.value = 400;
+```
+
+**Correct (pitch sweep):**
+
+```ts
+osc.frequency.setValueAtTime(400, t);
+osc.frequency.exponentialRampToValueAtTime(600, t + 0.04);
+```
+
+### 6.9 Bandpass Filter for Sound Character
+
+Apply bandpass filter to shape percussive sounds.
+
+**Incorrect (raw noise):**
+
+```ts
+source.connect(gain).connect(ctx.destination);
+```
+
+**Correct (filtered noise):**
+
+```ts
+const filter = ctx.createBiquadFilter();
+filter.type = "bandpass";
+filter.frequency.value = 4000;
+filter.Q.value = 3;
+source.connect(filter).connect(gain).connect(ctx.destination);
+```
+
+### 6.10 Click Duration 5-15ms
+
+Click/tap sounds should be 5-15ms duration.
+
+**Incorrect (too long):**
+
+```ts
+const buffer = ctx.createBuffer(1, ctx.sampleRate * 0.1, ctx.sampleRate);
+```
+
+**Correct (appropriate duration):**
+
+```ts
+const buffer = ctx.createBuffer(1, ctx.sampleRate * 0.008, ctx.sampleRate);
+```
+
+### 6.11 Click Filter 3000-6000Hz
+
+Bandpass filter for clicks should be 3000-6000Hz.
+
+**Incorrect (too low):**
+
+```ts
+filter.frequency.value = 500;
+```
+
+**Correct (crisp range):**
+
+```ts
+filter.frequency.value = 4000;
+```
+
+### 6.12 Gain Under 1.0
+
+Gain values should not exceed 1.0 to prevent clipping.
+
+**Incorrect (clipping):**
+
+```ts
+gain.gain.setValueAtTime(1.5, t);
+```
+
+**Correct (safe gain):**
+
+```ts
+gain.gain.setValueAtTime(0.3, t);
+```
+
+### 6.13 Filter Q Value 2-5
+
+Filter Q for clicks should be 2-5 for focused but not harsh sound.
+
+**Incorrect (too resonant):**
+
+```ts
+filter.Q.value = 15;
+```
+
+**Correct (balanced Q):**
+
+```ts
+filter.Q.value = 3;
+```
+
+**Parameter translation table:**
+
+| User Says | Parameter Change |
+|-----------|------------------|
+| "too harsh" | Lower filter frequency, reduce Q |
+| "too muffled" | Higher filter frequency |
+| "too long" | Shorter duration, faster decay |
+| "cuts off abruptly" | Use exponential decay |
+| "more mechanical" | Higher Q, faster decay |
+| "softer" | Lower gain, triangle wave |
+
+Reference: [Web Audio API - MDN](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API)
+
+---
+
+## 7. Morphing Icons
+
+**Impact:** LOW — Building icon components that morph between any two icons through SVG line transformation.
+
+**Core concept:** Every icon is composed of exactly three SVG lines. Icons that need fewer lines collapse the extras to invisible center points. This constraint enables seamless morphing between any two icons.
+
+**Architecture:**
+
+```ts
+interface IconLine {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  opacity?: number;
+}
+
+interface IconDefinition {
+  lines: [IconLine, IconLine, IconLine];
+  rotation?: number;
+  group?: string;
+}
+
+const CENTER = 7;
+const collapsed: IconLine = {
+  x1: CENTER, y1: CENTER, x2: CENTER, y2: CENTER, opacity: 0,
+};
+```
+
+### 7.1 Icons Must Use Exactly Three Lines
+
+Every icon MUST use exactly 3 lines. No more, no fewer.
+
+**Incorrect (only 2 lines):**
+
+```ts
+const checkIcon = {
+  lines: [
+    { x1: 2, y1: 7.5, x2: 5.5, y2: 11 },
+    { x1: 5.5, y1: 11, x2: 12, y2: 3 },
+  ],
+};
+```
+
+**Correct (3 lines with collapsed):**
+
+```ts
+const checkIcon = {
+  lines: [
+    { x1: 2, y1: 7.5, x2: 5.5, y2: 11 },
+    { x1: 5.5, y1: 11, x2: 12, y2: 3 },
+    collapsed,
+  ],
+};
+```
+
+### 7.2 Use Collapsed Constant for Unused Lines
+
+Unused lines must use the collapsed constant, not omission or null.
+
+**Incorrect (null for unused):**
+
+```ts
+const minusIcon = {
+  lines: [
+    { x1: 2, y1: 7, x2: 12, y2: 7 },
+    null,
+    null,
+  ],
+};
+```
+
+**Correct (collapsed constant):**
+
+```ts
+const minusIcon = {
+  lines: [
+    { x1: 2, y1: 7, x2: 12, y2: 7 },
+    collapsed,
+    collapsed,
+  ],
+};
+```
+
+### 7.3 Consistent ViewBox Size
+
+All icons must use the same viewBox (14x14 recommended).
+
+**Incorrect (mixed scales):**
+
+```ts
+const icon1 = { lines: [{ x1: 2, y1: 7, x2: 12, y2: 7 }, ...] }; // 14x14
+const icon2 = { lines: [{ x1: 4, y1: 14, x2: 24, y2: 14 }, ...] }; // 28x28
+```
+
+**Correct (consistent scale):**
+
+```ts
+const VIEWBOX_SIZE = 14;
+const CENTER = 7;
+```
+
+### 7.4 Shared Group for Rotational Variants
+
+Icons that are rotational variants MUST share the same group and base lines.
+
+**Incorrect (different line definitions):**
+
+```ts
+const arrowRight = { lines: [{ x1: 2, y1: 7, x2: 12, y2: 7 }, ...] };
+const arrowDown = { lines: [{ x1: 7, y1: 2, x2: 7, y2: 12 }, ...] };
+```
+
+**Correct (shared base lines):**
+
+```ts
+const arrowLines: [IconLine, IconLine, IconLine] = [
+  { x1: 2, y1: 7, x2: 12, y2: 7 },
+  { x1: 7.5, y1: 2.5, x2: 12, y2: 7 },
+  { x1: 7.5, y1: 11.5, x2: 12, y2: 7 },
+];
+
+const icons = {
+  "arrow-right": { lines: arrowLines, rotation: 0, group: "arrow" },
+  "arrow-down": { lines: arrowLines, rotation: 90, group: "arrow" },
+  "arrow-left": { lines: arrowLines, rotation: 180, group: "arrow" },
+  "arrow-up": { lines: arrowLines, rotation: -90, group: "arrow" },
+};
+```
+
+### 7.5 Spring Physics for Rotation
+
+Rotation between grouped icons should use spring physics for natural motion.
+
+**Incorrect (duration-based rotation):**
+
+```tsx
+<motion.g animate={{ rotate: rotation }} transition={{ duration: 0.3 }} />
+```
+
+**Correct (spring rotation):**
+
+```tsx
+const rotation = useSpring(definition.rotation ?? 0, activeTransition);
+
+<motion.g style={{ rotate: rotation, transformOrigin: "center" }} />
+```
+
+### 7.6 Reduced Motion Support for Icons
+
+Respect prefers-reduced-motion by disabling animations.
+
+**Incorrect (always animates):**
+
+```tsx
+function MorphingIcon({ icon }: Props) {
+  return <motion.line animate={...} transition={{ duration: 0.4 }} />;
+}
+```
+
+**Correct (respects preference):**
+
+```tsx
+function MorphingIcon({ icon }: Props) {
+  const reducedMotion = useReducedMotion() ?? false;
+  const activeTransition = reducedMotion ? { duration: 0 } : transition;
+
+  return <motion.line animate={...} transition={activeTransition} />;
+}
+```
+
+### 7.7 Instant Jump for Non-Grouped Icons
+
+When transitioning between icons NOT in the same group, rotation should jump instantly.
+
+**Incorrect (always animates rotation):**
+
+```tsx
+useEffect(() => {
+  rotation.set(definition.rotation ?? 0);
+}, [definition]);
+```
+
+**Correct (jumps when not grouped):**
+
+```tsx
+useEffect(() => {
+  if (shouldRotate) {
+    rotation.set(definition.rotation ?? 0);
+  } else {
+    rotation.jump(definition.rotation ?? 0);
+  }
+}, [definition, shouldRotate]);
+```
+
+### 7.8 Round Stroke Line Caps
+
+Lines should use strokeLinecap="round" for polished endpoints.
+
+**Incorrect (butt caps):**
+
+```tsx
+<motion.line strokeLinecap="butt" />
+```
+
+**Correct (round caps):**
+
+```tsx
+<motion.line strokeLinecap="round" />
+```
+
+### 7.9 Aria Hidden on Icon SVGs
+
+Icon SVGs should be aria-hidden since they're decorative.
+
+**Incorrect (no aria attribute):**
+
+```tsx
+<svg width={size} height={size}>...</svg>
+```
+
+**Correct (aria-hidden):**
+
+```tsx
+<svg width={size} height={size} aria-hidden="true">...</svg>
+```
+
+**Common icon patterns:**
+
+```ts
+// Two-line icons (check, minus, chevron) — one collapsed line
+const check = {
+  lines: [
+    { x1: 2, y1: 7.5, x2: 5.5, y2: 11 },
+    { x1: 5.5, y1: 11, x2: 12, y2: 3 },
+    collapsed,
+  ],
+};
+
+// Three-line icons (menu, asterisk) — all lines used
+const menu = {
+  lines: [
+    { x1: 2, y1: 3.5, x2: 12, y2: 3.5 },
+    { x1: 2, y1: 7, x2: 12, y2: 7 },
+    { x1: 2, y1: 10.5, x2: 12, y2: 10.5 },
+  ],
+};
+
+// Point icons (more, grip) — zero-length lines as dots
+const more = {
+  lines: [
+    { x1: 3, y1: 7, x2: 3, y2: 7 },
+    { x1: 7, y1: 7, x2: 7, y2: 7 },
+    { x1: 11, y1: 7, x2: 11, y2: 7 },
+  ],
+};
+```
+
+**Recommended transition:**
+
+```ts
+const defaultTransition: Transition = {
+  ease: [0.19, 1, 0.22, 1],
+  duration: 0.4,
+};
+```
+
+Reference: [Motion useSpring](https://motion.dev/docs/react-use-spring), [SVG Line Element](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/line)
+
+---
+
+## 8. Container Animation
+
+**Impact:** MEDIUM — Animating container width and height using a measure-and-animate pattern with ResizeObserver and Motion.
+
+### 8.1 Two-Div Pattern for Animated Bounds
+
+Use an outer animated div and an inner measured div. Never measure and animate the same element — it creates a feedback loop.
+
+**Incorrect (measure and animate same element):**
+
+```tsx
+function AnimatedContainer({ children }) {
+  const [ref, bounds] = useMeasure();
+  return (
+    <motion.div ref={ref} animate={{ height: bounds.height }}>
+      {children}
+    </motion.div>
+  );
+}
+```
+
+**Correct (separate measure and animate targets):**
+
+```tsx
+function AnimatedContainer({ children }) {
+  const [ref, bounds] = useMeasure();
+  return (
+    <motion.div animate={{ height: bounds.height }}>
+      <div ref={ref}>{children}</div>
+    </motion.div>
+  );
+}
+```
+
+### 8.2 Guard Against Zero on Initial Render
+
+On initial render, measured bounds are 0. Guard against this to prevent animating from 0 to actual size.
+
+**Incorrect (animates from 0 on mount):**
+
+```tsx
+<motion.div animate={{ width: bounds.width }}>
+  <div ref={ref}>{children}</div>
+</motion.div>
+```
+
+**Correct (falls back to auto on first frame):**
+
+```tsx
+<motion.div animate={{ width: bounds.width > 0 ? bounds.width : "auto" }}>
+  <div ref={ref}>{children}</div>
+</motion.div>
+```
+
+### 8.3 Use ResizeObserver for Measurement
+
+Use ResizeObserver to track element dimensions. It fires on resize without causing layout thrashing.
+
+**Incorrect (measuring on every render):**
+
+```tsx
+function useMeasure(ref) {
+  const [bounds, setBounds] = useState({ width: 0, height: 0 });
+  useEffect(() => {
+    if (ref.current) {
+      const rect = ref.current.getBoundingClientRect();
+      setBounds({ width: rect.width, height: rect.height });
+    }
+  });
+  return bounds;
+}
+```
+
+**Correct (ResizeObserver):**
+
+```tsx
+function useMeasure() {
+  const [element, setElement] = useState(null);
+  const [bounds, setBounds] = useState({ width: 0, height: 0 });
+  const ref = useCallback((node) => setElement(node), []);
+
+  useEffect(() => {
+    if (!element) return;
+    const observer = new ResizeObserver(([entry]) => {
+      setBounds({
+        width: entry.contentRect.width,
+        height: entry.contentRect.height,
+      });
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [element]);
+
+  return [ref, bounds];
+}
+```
+
+### 8.4 Overflow Hidden on Animated Container
+
+Set overflow: hidden on the animated outer container to clip content during size transitions.
+
+**Incorrect (content overflows during animation):**
+
+```tsx
+<motion.div animate={{ height: bounds.height }}>
+  <div ref={ref}>{children}</div>
+</motion.div>
+```
+
+**Correct (clipped during transition):**
+
+```tsx
+<motion.div animate={{ height: bounds.height }} style={{ overflow: "hidden" }}>
+  <div ref={ref}>{children}</div>
+</motion.div>
+```
+
+### 8.5 Use Animated Bounds Sparingly
+
+Animated bounds is a subtle effect. Reserve it for interactive elements where size changes are meaningful.
+
+**Good use cases:** loading state buttons, expandable sections, accordions, FAQs, content reveals.
+
+**Bad use cases:** every container on the page, static layouts, elements that don't change size.
+
+### 8.6 Use Callback Ref for Measurement
+
+Use a callback ref (not useRef) for measurement hooks so the observer attaches when the DOM node is ready.
+
+**Incorrect (useRef may be null on first effect):**
+
+```tsx
+const ref = useRef(null);
+useEffect(() => {
+  if (!ref.current) return;
+  observer.observe(ref.current);
+}, []);
+```
+
+**Correct (callback ref guarantees node):**
+
+```tsx
+const [element, setElement] = useState(null);
+const ref = useCallback((node) => setElement(node), []);
+useEffect(() => {
+  if (!element) return;
+  observer.observe(element);
+  return () => observer.disconnect();
+}, [element]);
+```
+
+### 8.7 Add Delay for Natural Container Transitions
+
+Add a small delay so the transition feels like it's catching up to the content.
+
+**Correct:**
+
+```tsx
+<motion.div
+  animate={{ height: bounds.height }}
+  transition={{ duration: 0.2, delay: 0.05 }}
+  style={{ overflow: "hidden" }}
+>
+  <div ref={ref}>{children}</div>
+</motion.div>
+```
+
+Reference: [ResizeObserver - MDN](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver), [Motion Documentation](https://motion.dev)
+
+---
+
+## 9. Laws of UX
+
+**Impact:** HIGH — Psychological principles behind interfaces that feel right. Violating these creates friction users can't articulate.
+
+### 9.1 Size Interactive Targets for Easy Clicking
+
+The bigger something is, the easier it is to click (Fitts's Law). Make interactive elements at least 32px.
+
+**Incorrect (tiny click target):**
+
+```css
+.icon-button {
+  width: 16px;
+  height: 16px;
+  padding: 0;
+}
+```
+
+**Correct (comfortable target):**
+
+```css
+.icon-button {
+  width: 32px;
+  height: 32px;
+  padding: 8px;
+}
+```
+
+### 9.2 Expand Hit Areas with Invisible Padding
+
+Use pseudo-elements or invisible padding to expand clickable areas beyond visible bounds.
+
+**Incorrect (visible size equals hit area):**
+
+```css
+.link {
+  font-size: 14px;
+}
+```
+
+**Correct (expanded invisible hit area):**
+
+```css
+.link {
+  position: relative;
+}
+
+.link::before {
+  content: "";
+  position: absolute;
+  inset: -8px -12px;
+}
+```
+
+### 9.3 Minimize Choices to Reduce Decision Time
+
+Decision time increases logarithmically with the number of choices (Hick's Law). Use progressive disclosure.
+
+**Incorrect (all options at once):**
+
+```tsx
+function Settings() {
+  return (
+    <div>
+      {allSettings.map(setting => (
+        <SettingRow key={setting.id} {...setting} />
+      ))}
+    </div>
+  );
+}
+```
+
+**Correct (progressive disclosure):**
+
+```tsx
+function Settings() {
+  return (
+    <div>
+      {commonSettings.map(setting => (
+        <SettingRow key={setting.id} {...setting} />
+      ))}
+      <details>
+        <summary>Advanced</summary>
+        {advancedSettings.map(setting => (
+          <SettingRow key={setting.id} {...setting} />
+        ))}
+      </details>
+    </div>
+  );
+}
+```
+
+### 9.4 Chunk Data into Groups of 5-9
+
+Working memory holds about 7 items (Miller's Law). Group and chunk large data sets for scannability.
+
+**Incorrect (raw unformatted data):**
+
+```tsx
+<span>4532015112830366</span>
+```
+
+**Correct (chunked for readability):**
+
+```tsx
+<span>4532 0151 1283 0366</span>
+```
+
+### 9.5 Respond Within 400ms
+
+Interactions must respond within 400ms to feel instant (Doherty Threshold). Above this, users notice delay.
+
+**Incorrect (no feedback during loading):**
+
+```tsx
+async function handleClick() {
+  const data = await fetchData();
+  setResult(data);
+}
+```
+
+**Correct (immediate optimistic feedback):**
+
+```tsx
+async function handleClick() {
+  setResult(optimisticData);
+  const data = await fetchData();
+  setResult(data);
+}
+```
+
+### 9.6 Fake Speed When Actual Speed Isn't Possible
+
+If you can't make something fast, make it feel fast with optimistic UI, skeletons, or progress indicators.
+
+**Incorrect (blank screen during load):**
+
+```tsx
+function Page() {
+  const { data, isLoading } = useFetch("/api/data");
+  if (isLoading) return null;
+  return <Content data={data} />;
+}
+```
+
+**Correct (skeleton during load):**
+
+```tsx
+function Page() {
+  const { data, isLoading } = useFetch("/api/data");
+  if (isLoading) return <Skeleton />;
+  return <Content data={data} />;
+}
+```
+
+### 9.7 Accept Messy Input, Output Clean Data
+
+Inputs should accept messy human data and normalize it (Postel's Law). Validate generously, format strictly.
+
+**Incorrect (rigid format required):**
+
+```tsx
+function DateInput({ onChange }) {
+  return (
+    <input
+      type="text"
+      placeholder="YYYY-MM-DD"
+      pattern="\d{4}-\d{2}-\d{2}"
+      onChange={onChange}
+    />
+  );
+}
+```
+
+**Correct (accepts multiple formats):**
+
+```tsx
+function DateInput({ onChange }) {
+  function handleChange(e) {
+    const parsed = parseFlexibleDate(e.target.value);
+    if (parsed) onChange(parsed);
+  }
+
+  return (
+    <input
+      type="text"
+      placeholder="Any date format"
+      onChange={handleChange}
+    />
+  );
+}
+```
+
+### 9.8 Show What Matters Now, Reveal Complexity Later
+
+Don't overwhelm users with everything at once. Reveal complexity incrementally as needed.
+
+**Incorrect (all controls visible):**
+
+```tsx
+function Editor() {
+  return (
+    <div>
+      <BasicTools />
+      <AdvancedTools />
+      <ExpertTools />
+      <DebugTools />
+    </div>
+  );
+}
+```
+
+**Correct (progressive disclosure):**
+
+```tsx
+function Editor() {
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  return (
+    <div>
+      <BasicTools />
+      {showAdvanced && <AdvancedTools />}
+      <button onClick={() => setShowAdvanced(!showAdvanced)}>
+        Toggle
+      </button>
+    </div>
+  );
+}
+```
+
+### 9.9 Use Familiar UI Patterns
+
+Users spend most of their time on other sites. They expect yours to work the same way (Jakob's Law).
+
+**Incorrect (custom unconventional navigation):**
+
+```tsx
+function Nav() {
+  return (
+    <nav>
+      <button onClick={() => navigate("/")}>⬡</button>
+      <button onClick={() => navigate("/search")}>⬢</button>
+    </nav>
+  );
+}
+```
+
+**Correct (standard recognizable patterns):**
+
+```tsx
+function Nav() {
+  return (
+    <nav>
+      <Link href="/">Home</Link>
+      <Link href="/search">Search</Link>
+    </nav>
+  );
+}
+```
+
+### 9.10 Visual Polish Increases Perceived Usability
+
+Users perceive aesthetically pleasing design as more usable. Small visual details compound into trust.
+
+**Incorrect (unstyled, raw elements):**
+
+```css
+.card {
+  border: 1px solid black;
+  padding: 10px;
+}
+```
+
+**Correct (considered visual treatment):**
+
+```css
+.card {
+  padding: 16px;
+  background: var(--gray-2);
+  border: 1px solid var(--gray-a4);
+  border-radius: 12px;
+  box-shadow: var(--shadow-1);
+}
+```
+
+### 9.11 Group Related Elements Spatially
+
+Elements near each other are perceived as related (Law of Proximity). Use spacing to create visual groups.
+
+**Incorrect (uniform spacing between unrelated items):**
+
+```css
+.form label,
+.form input,
+.form .hint,
+.form .divider {
+  margin-bottom: 16px;
+}
+```
+
+**Correct (tighter spacing within groups, larger between):**
+
+```css
+.form label {
+  margin-bottom: 4px;
+}
+
+.form input {
+  margin-bottom: 2px;
+}
+
+.form .hint {
+  margin-bottom: 24px;
+}
+```
+
+### 9.12 Similar Elements Should Look Alike
+
+Elements that function the same should look the same (Law of Similarity). Visual consistency signals functional consistency.
+
+**Incorrect (same function, different appearance):**
+
+```css
+.save-button {
+  background: blue;
+  border-radius: 8px;
+}
+
+.submit-button {
+  background: green;
+  border-radius: 0;
+}
+```
+
+**Correct (same function, same appearance):**
+
+```css
+.primary-action {
+  background: var(--gray-12);
+  color: var(--gray-1);
+  border-radius: 8px;
+}
+```
+
+### 9.13 Use Boundaries to Group Related Content
+
+Elements sharing a clearly defined boundary are perceived as a group (Law of Common Region).
+
+**Incorrect (flat list with no visual grouping):**
+
+```tsx
+function Settings() {
+  return (
+    <div>
+      <Toggle label="Dark mode" />
+      <Toggle label="Notifications" />
+      <Input label="Email" />
+      <Input label="Password" />
+    </div>
+  );
+}
+```
+
+**Correct (bounded sections):**
+
+```tsx
+function Settings() {
+  return (
+    <div>
+      <section className={styles.group}>
+        <h3>Appearance</h3>
+        <Toggle label="Dark mode" />
+      </section>
+      <section className={styles.group}>
+        <h3>Account</h3>
+        <Input label="Email" />
+        <Input label="Password" />
+      </section>
+    </div>
+  );
+}
+```
+
+### 9.14 Make Important Elements Visually Distinct
+
+When multiple similar elements are present, the one that differs is most likely to be remembered (Von Restorff Effect).
+
+**Incorrect (primary action blends in):**
+
+```tsx
+<div className={styles.actions}>
+  <button className={styles.button}>Cancel</button>
+  <button className={styles.button}>Delete Account</button>
+</div>
+```
+
+**Correct (destructive action stands out):**
+
+```tsx
+<div className={styles.actions}>
+  <button className={styles["button-secondary"]}>Cancel</button>
+  <button className={styles["button-danger"]}>Delete Account</button>
+</div>
+```
+
+### 9.15 Place Key Items First or Last
+
+Users best remember the first and last items in a sequence (Serial Position Effect).
+
+**Incorrect (important action buried in middle):**
+
+```tsx
+<nav>
+  <Link href="/settings">Settings</Link>
+  <Link href="/">Home</Link>
+  <Link href="/about">About</Link>
+</nav>
+```
+
+**Correct (key items at edges):**
+
+```tsx
+<nav>
+  <Link href="/">Home</Link>
+  <Link href="/about">About</Link>
+  <Link href="/settings">Settings</Link>
+</nav>
+```
+
+### 9.16 End Experiences with Clear Success States
+
+People judge experiences by their peak moment and their end (Peak-End Rule). Invest in completion states.
+
+**Incorrect (abrupt end after action):**
+
+```tsx
+async function handleSubmit() {
+  await submitForm(data);
+  router.push("/");
+}
+```
+
+**Correct (satisfying completion state):**
+
+```tsx
+async function handleSubmit() {
+  await submitForm(data);
+  setStatus("success");
+}
+
+return status === "success" ? (
+  <SuccessScreen message="You're all set." />
+) : (
+  <Form onSubmit={handleSubmit} />
+);
+```
+
+### 9.17 Move Complexity to the System
+
+Every system has irreducible complexity (Tesler's Law). The question is who handles it — the user or the system.
+
+**Incorrect (complexity pushed to user):**
+
+```tsx
+<input
+  type="text"
+  placeholder="Enter date as YYYY-MM-DDTHH:mm:ss.sssZ"
+/>
+```
+
+**Correct (system absorbs complexity):**
+
+```tsx
+<DatePicker
+  onChange={(date) => setDate(date.toISOString())}
+/>
+```
+
+### 9.18 Show Progress Toward Completion
+
+People accelerate behavior as they approach a goal (Goal-Gradient Effect). Show how close they are.
+
+**Incorrect (no sense of progress):**
+
+```tsx
+function Onboarding({ step }) {
+  return <OnboardingStep step={step} />;
+}
+```
+
+**Correct (progress visible):**
+
+```tsx
+function Onboarding({ step, totalSteps }) {
+  return (
+    <div>
+      <ProgressBar value={step} max={totalSteps} />
+      <span>Step {step} of {totalSteps}</span>
+      <OnboardingStep step={step} />
+    </div>
+  );
+}
+```
+
+### 9.19 Show Incomplete State to Drive Completion
+
+People remember incomplete tasks better than completed ones (Zeigarnik Effect).
+
+**Incorrect (no indication of incomplete profile):**
+
+```tsx
+function Dashboard() {
+  return <DashboardContent />;
+}
+```
+
+**Correct (incomplete state visible):**
+
+```tsx
+function Dashboard({ profile }) {
+  return (
+    <div>
+      {!profile.isComplete && (
+        <Banner>
+          Complete your profile — {profile.completionPercent}% done
+        </Banner>
+      )}
+      <DashboardContent />
+    </div>
+  );
+}
+```
+
+### 9.20 Simplify Complex Visuals into Clear Forms
+
+People interpret complex visuals as the simplest form possible (Law of Pragnanz). Reduce visual noise.
+
+**Incorrect (visually noisy layout):**
+
+```css
+.card {
+  border: 2px dashed red;
+  background: linear-gradient(45deg, #f0f, #0ff);
+  box-shadow: 5px 5px 0 black, 10px 10px 0 gray;
+  outline: 3px dotted blue;
+}
+```
+
+**Correct (clear, simple form):**
+
+```css
+.card {
+  background: var(--gray-2);
+  border: 1px solid var(--gray-a4);
+  border-radius: 12px;
+  box-shadow: var(--shadow-1);
+}
+```
+
+### 9.21 Prioritize the Critical 20% of Features
+
+80% of users use 20% of features (Pareto Principle). Optimize the critical path first.
+
+**Incorrect (all features equally prominent):**
+
+```tsx
+function Toolbar() {
+  return (
+    <div>
+      {allFeatures.map(f => <Button key={f.id}>{f.label}</Button>)}
+    </div>
+  );
+}
+```
+
+**Correct (critical features prominent, rest accessible):**
+
+```tsx
+function Toolbar() {
+  return (
+    <div>
+      {criticalFeatures.map(f => <Button key={f.id}>{f.label}</Button>)}
+      <MoreMenu features={secondaryFeatures} />
+    </div>
+  );
+}
+```
+
+### 9.22 Minimize Extraneous Cognitive Load
+
+Remove anything that doesn't help the user complete their task. Decoration, redundant labels, and unnecessary options all add load.
+
+**Incorrect (extraneous elements):**
+
+```tsx
+function DeleteDialog() {
+  return (
+    <dialog>
+      <Icon name="warning" size={64} />
+      <h2>Warning!</h2>
+      <p>Are you absolutely sure you want to delete?</p>
+      <p>This action is permanent and cannot be undone.</p>
+      <p>All associated data will be lost forever.</p>
+      <div>
+        <button>Cancel</button>
+        <button>Delete</button>
+        <button>Learn More</button>
+      </div>
+    </dialog>
+  );
+}
+```
+
+**Correct (essential information only):**
+
+```tsx
+function DeleteDialog() {
+  return (
+    <dialog>
+      <h2>Delete this item?</h2>
+      <p>This can't be undone.</p>
+      <div>
+        <button>Cancel</button>
+        <button>Delete</button>
+      </div>
+    </dialog>
+  );
+}
+```
+
+### 9.23 Visually Connect Related Elements
+
+Elements that are visually connected (by lines, color, or frames) are perceived as more related (Law of Uniform Connectedness).
+
+**Incorrect (steps with no visual connection):**
+
+```tsx
+function Steps({ current }) {
+  return (
+    <div>
+      <span>Step 1</span>
+      <span>Step 2</span>
+      <span>Step 3</span>
+    </div>
+  );
+}
+```
+
+**Correct (connected with a visual line):**
+
+```tsx
+function Steps({ current }) {
+  return (
+    <div className={styles.steps}>
+      {steps.map((step, i) => (
+        <div key={step.id} className={styles.step} data-active={i <= current}>
+          <div className={styles.dot} />
+          {i < steps.length - 1 && <div className={styles.connector} />}
+          <span>{step.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+Reference: [Laws of UX](https://lawsofux.com/) by Jon Yablonski
+
+---
+
+## 10. Predictive Prefetching
+
+**Impact:** MEDIUM — Loading content before the user clicks by analyzing cursor trajectory, reducing perceived latency by 100-200ms.
+
+### 10.1 Trajectory Prediction Over Hover Prefetching
+
+Hover prefetching starts too late. Trajectory prediction fires while the cursor is still in motion, reclaiming 100-200ms.
+
+**Incorrect (waits for hover):**
+
+```tsx
+<Link
+  href="/about"
+  onMouseEnter={() => router.prefetch("/about")}
+>
+  About
+</Link>
+```
+
+**Correct (trajectory-based):**
+
+```tsx
+const { elementRef } = useForesight({
+  callback: () => router.prefetch("/about"),
+  hitSlop: 20,
+  name: "about-link",
+});
+
+<Link ref={elementRef} href="/about">About</Link>
+```
+
+### 10.2 Prefetch by Intent, Not Viewport
+
+Don't prefetch everything visible in the viewport. Prefetch based on user intent to avoid wasted bandwidth.
+
+**Incorrect (prefetch all visible links):**
+
+```tsx
+<Link href="/page" prefetch={true}>Page</Link>
+```
+
+**Correct (intent-based prefetching):**
+
+```tsx
+<Link href="/page" prefetch={false}>Page</Link>
+```
+
+### 10.3 Use hitSlop to Trigger Predictions Earlier
+
+Expand the invisible prediction area around elements with hitSlop to start loading sooner.
+
+**Incorrect (tight prediction area):**
+
+```tsx
+const { elementRef } = useForesight({
+  callback: () => prefetch(),
+  hitSlop: 0,
+});
+```
+
+**Correct (expanded prediction area):**
+
+```tsx
+const { elementRef } = useForesight({
+  callback: () => prefetch(),
+  hitSlop: 20,
+});
+```
+
+### 10.4 Fall Back Gracefully on Touch Devices
+
+Touch devices have no cursor. Fall back to viewport or touch-start strategies automatically.
+
+**Incorrect (assumes cursor exists):**
+
+```tsx
+function PrefetchLink({ href, children }) {
+  return (
+    <Link
+      href={href}
+      onMouseMove={() => prefetch(href)}
+    >
+      {children}
+    </Link>
+  );
+}
+```
+
+**Correct (device-aware strategy):**
+
+```tsx
+const { elementRef } = useForesight({
+  callback: () => router.prefetch(href),
+  hitSlop: 20,
+});
+```
+
+### 10.5 Prefetch on Keyboard Navigation
+
+Monitor focus changes and prefetch when the user is a few tab stops away from a registered element.
+
+**Correct (tab-aware prefetching):**
+
+```tsx
+const { elementRef } = useForesight({
+  callback: () => router.prefetch("/settings"),
+  name: "settings-link",
+});
+```
+
+### 10.6 Use Predictive Prefetching Selectively
+
+Predictive prefetching doesn't belong in every project. Use it where navigation latency is noticeable.
+
+**Good use cases:** data-heavy dashboards, multi-page apps with slow API responses, e-commerce product pages.
+
+**Bad use cases:** static sites with instant navigation, single-page apps with all data preloaded.
+
+Reference: [ForesightJS](https://foresightjs.com), [Next.js Prefetching Docs](https://nextjs.org/docs/app/guides/prefetching)
+
+---
+
+## 11. Typography
+
+**Impact:** MEDIUM — CSS font and text properties most developers overlook. The difference between typographically considered and not.
+
+### 11.1 Tabular Numbers for Data Display
+
+Use tabular-nums for any numeric data that should align in columns.
+
+**Incorrect (proportional numbers misalign):**
+
+```css
+.price { font-variant-numeric: proportional-nums; }
+```
+
+**Correct (tabular numbers align):**
+
+```css
+.price { font-variant-numeric: tabular-nums; }
+```
+
+### 11.2 Oldstyle Numbers for Body Text
+
+Use oldstyle-nums in body text so numbers blend with lowercase letters. Use lining-nums in tables and headings.
+
+**Correct (prose):**
+
+```css
+.body-text { font-variant-numeric: oldstyle-nums; }
+```
+
+**Correct (data):**
+
+```css
+.data-table { font-variant-numeric: lining-nums tabular-nums; }
+```
+
+### 11.3 Slashed Zero for Disambiguation
+
+Enable slashed zero in code-adjacent UIs so users never confuse 0 with O.
+
+**Correct:**
+
+```css
+.code { font-variant-numeric: slashed-zero; }
+```
+
+### 11.4 Enable Contextual Alternates
+
+Keep contextual alternates (calt) enabled. They adjust punctuation and glyph shapes based on surrounding characters.
+
+**Correct (usually on by default — don't disable):**
+
+```css
+body { font-feature-settings: "calt" 1; }
+```
+
+### 11.5 Use Disambiguation Stylistic Set for UI
+
+Enable ss02 (or your font's disambiguation set) in code-facing UIs to distinguish I, l, 1 and 0, O.
+
+**Correct:**
+
+```css
+.code-ui { font-feature-settings: "ss02"; }
+```
+
+### 11.6 Keep Optical Sizing Auto
+
+Leave font-optical-sizing at auto. The font adjusts glyph shapes for the current size — thicker strokes at small sizes, finer details at large sizes.
+
+**Incorrect (forced off):**
+
+```css
+body { font-optical-sizing: none; }
+```
+
+**Correct (automatic adjustment):**
+
+```css
+body { font-optical-sizing: auto; }
+```
+
+### 11.7 Use Antialiased Font Smoothing
+
+Set -webkit-font-smoothing: antialiased on retina displays. Default subpixel rendering looks thicker and fuzzier.
+
+**Correct:**
+
+```css
+body {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+```
+
+### 11.8 Balance Headings with text-wrap
+
+Use text-wrap: balance on headings to make lines roughly equal length instead of one long line and a short orphan.
+
+**Incorrect (unbalanced heading):**
+
+```css
+h1 { /* default text-wrap */ }
+```
+
+**Correct (balanced):**
+
+```css
+h1 { text-wrap: balance; }
+```
+
+### 11.9 Offset Underlines from Descenders
+
+Use text-underline-offset to push underlines below descenders so they look intentional.
+
+**Incorrect (underline collides with descenders):**
+
+```css
+a { text-decoration: underline; }
+```
+
+**Correct (offset underline):**
+
+```css
+a {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-skip-ink: auto;
+}
+```
+
+### 11.10 Disable Font Synthesis for Missing Styles
+
+Set font-synthesis: none to prevent the browser from faking bold or italic. Browser-generated faux styles look terrible.
+
+**Correct:**
+
+```css
+.icon-font,
+.display-font {
+  font-synthesis: none;
+}
+```
+
+**Typography quick reference:**
+
+| Property | Use Case | Value |
+|----------|----------|-------|
+| `font-variant-numeric: tabular-nums` | Data tables, pricing | Fixed-width digits |
+| `font-variant-numeric: oldstyle-nums` | Body text | Blends with lowercase |
+| `font-variant-numeric: slashed-zero` | Code UIs | Distinguishes 0 from O |
+| `font-feature-settings: "ss02"` | Code UIs | Disambiguates I/l/1 |
+| `font-optical-sizing: auto` | Everywhere | Size-adaptive glyphs |
+| `-webkit-font-smoothing: antialiased` | Retina displays | Thinner, cleaner text |
+| `text-wrap: balance` | Headings | Even line lengths |
+| `text-underline-offset: 3px` | Links | Clear descender space |
+| `font-synthesis: none` | Display/icon fonts | Prevents faux styles |
+
+### 11.11 Use font-display swap
+
+Set font-display: swap so text renders immediately with a fallback while the custom font loads.
+
+**Correct:**
+
+```css
+@font-face {
+  font-family: "Inter";
+  src: url("/fonts/inter.woff2") format("woff2");
+  font-display: swap;
+}
+```
+
+### 11.12 Continuous Weight Values with Variable Fonts
+
+Variable fonts accept any integer from 100-900, not just standard stops.
+
+**Correct (precise weight):**
+
+```css
+.medium { font-weight: 450; }
+.semibold { font-weight: 550; }
+```
+
+### 11.13 text-wrap pretty for Body Text
+
+Use text-wrap: pretty for body text to reduce orphans. Use balance for headings.
+
+**Correct:**
+
+```css
+p { text-wrap: pretty; }
+h1, h2, h3 { text-wrap: balance; }
+```
+
+### 11.14 Pair Justified Text with Hyphens
+
+Justified text without hyphens creates rivers of whitespace.
+
+**Incorrect (rivers):**
+
+```css
+.article { text-align: justify; }
+```
+
+**Correct (hyphenation prevents rivers):**
+
+```css
+.article {
+  text-align: justify;
+  hyphens: auto;
+}
+```
+
+### 11.15 Add Letter Spacing to Uppercase Text
+
+Uppercase and small-caps text needs positive letter-spacing to feel open and readable.
+
+**Incorrect (tight uppercase):**
+
+```css
+.label {
+  text-transform: uppercase;
+  font-size: 12px;
+}
+```
+
+**Correct (opened up):**
+
+```css
+.label {
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.05em;
+}
+```
+
+### 11.16 Use Typographic Fractions
+
+Enable diagonal-fractions to convert 1/2, 1/3 into proper typographic fractions.
+
+**Correct:**
+
+```css
+.recipe { font-variant-numeric: diagonal-fractions; }
+```
+
+Reference: [Inter Typeface](https://rsms.me/inter/), [MDN font-feature-settings](https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings), [MDN font-variant-numeric](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric)
+
+---
+
+## 12. Visual Design
+
+**Impact:** HIGH — CSS design fundamentals that compound into visual polish. Small details that separate considered interfaces from default ones.
+
+### 12.1 Concentric Border Radius for Nested Elements
+
+When nesting rounded elements, inner radius must equal outer radius minus the gap. Same radius on both creates uneven curves.
+
+**Incorrect (same radius on both):**
+
+```css
+.outer {
+  border-radius: 16px;
+  padding: 8px;
+}
+
+.inner {
+  border-radius: 16px;
+}
+```
+
+**Correct (concentric radius):**
+
+```css
+.outer {
+  --padding: 8px;
+  --inner-radius: 8px;
+
+  border-radius: calc(var(--inner-radius) + var(--padding));
+  padding: var(--padding);
+}
+
+.inner {
+  border-radius: var(--inner-radius);
+}
+```
+
+### 12.2 Layer Multiple Shadows for Realistic Depth
+
+A single box-shadow looks flat. Layer multiple shadows with increasing blur and decreasing opacity to mimic real light.
+
+**Incorrect (single flat shadow):**
+
+```css
+.card {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+```
+
+**Correct (layered shadows):**
+
+```css
+.card {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.06),
+    0 4px 8px rgba(0, 0, 0, 0.04),
+    0 12px 24px rgba(0, 0, 0, 0.03);
+}
+```
+
+### 12.3 Consistent Shadow Direction Across UI
+
+All shadows must share the same offset direction to imply a single light source. Mixed directions feel broken.
+
+**Incorrect (conflicting light sources):**
+
+```css
+.card { box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); }
+.modal { box-shadow: 4px 0 8px rgba(0, 0, 0, 0.1); }
+.tooltip { box-shadow: 0 -4px 8px rgba(0, 0, 0, 0.1); }
+```
+
+**Correct (consistent top-down light):**
+
+```css
+.card { box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08); }
+.modal { box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12); }
+.tooltip { box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1); }
+```
+
+### 12.4 Use Neutral Colors for Shadows
+
+Pure black shadows look harsh. Use deep neutrals or semi-transparent dark colors.
+
+**Incorrect (pure black):**
+
+```css
+.card {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+}
+```
+
+**Correct (neutral shadow):**
+
+```css
+.card {
+  box-shadow: 0 4px 12px rgba(17, 24, 39, 0.08);
+}
+```
+
+### 12.5 Shadow Size Indicates Elevation
+
+Larger blur and offset means higher elevation. Use a consistent shadow scale.
+
+**Correct (elevation scale):**
+
+```css
+:root {
+  --shadow-1: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-2: 0 2px 8px rgba(0, 0, 0, 0.08);
+  --shadow-3: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+.card { box-shadow: var(--shadow-1); }
+.dropdown { box-shadow: var(--shadow-2); }
+.modal { box-shadow: var(--shadow-3); }
+```
+
+### 12.6 Animate Shadows via Pseudo-Element Opacity
+
+Transitioning box-shadow directly forces expensive repaints. Animate opacity on a pseudo-element instead.
+
+**Incorrect (animating box-shadow):**
+
+```css
+.card {
+  box-shadow: var(--shadow-1);
+  transition: box-shadow 0.2s ease;
+}
+.card:hover {
+  box-shadow: var(--shadow-3);
+}
+```
+
+**Correct (pseudo-element opacity):**
+
+```css
+.card {
+  position: relative;
+  box-shadow: var(--shadow-1);
+}
+.card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: var(--shadow-3);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+  z-index: -1;
+}
+.card:hover::after {
+  opacity: 1;
+}
+```
+
+### 12.7 Use a Consistent Spacing Scale
+
+Don't use arbitrary pixel values. Define a scale and use it throughout.
+
+**Incorrect (arbitrary values):**
+
+```css
+.header { padding: 17px; }
+.card { margin-bottom: 13px; }
+.section { gap: 22px; }
+```
+
+**Correct (consistent scale):**
+
+```css
+:root {
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+}
+
+.header { padding: var(--space-4); }
+.card { margin-bottom: var(--space-3); }
+.section { gap: var(--space-5); }
+```
+
+### 12.8 Use Semi-Transparent Borders
+
+Semi-transparent borders adapt to any background color and create subtle, non-jarring separation.
+
+**Incorrect (hardcoded border color):**
+
+```css
+.card {
+  border: 1px solid #e5e5e5;
+}
+```
+
+**Correct (alpha border):**
+
+```css
+.card {
+  border: 1px solid var(--gray-a4);
+}
+```
+
+### 12.9 Full Shadow Anatomy on Buttons
+
+A polished button uses six layered techniques, not just a single box-shadow:
+
+1. **Outer cut shadow** — 0.5px dark box-shadow to "cut" the button into the surface
+2. **Inner ambient highlight** — 1px inset box-shadow on all sides for environmental light reflections
+3. **Inner top highlight** — 1px inset top highlight for the primary light source from above
+4. **Layered depth shadows** — At least 3 external shadows for natural lighting
+5. **Text drop-shadow** — Drop-shadow on text/icons for better contrast against the button background
+6. **Subtle gradient background** — If you can tell there's a gradient, it's too much
+
+**Incorrect (flat button):**
+
+```css
+.button {
+  background: var(--gray-12);
+  color: var(--gray-1);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+```
+
+**Correct (full shadow anatomy):**
+
+```css
+.button {
+  background: linear-gradient(
+    to bottom,
+    color-mix(in srgb, var(--gray-12) 100%, white 4%),
+    var(--gray-12)
+  );
+  color: var(--gray-1);
+  box-shadow:
+    0 0 0 0.5px rgba(0, 0, 0, 0.3),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.04),
+    inset 0 1px 0 rgba(255, 255, 255, 0.07),
+    0 1px 2px rgba(0, 0, 0, 0.1),
+    0 2px 4px rgba(0, 0, 0, 0.06),
+    0 4px 8px rgba(0, 0, 0, 0.03);
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15);
+}
+```
+
+Reference: [Designing Beautiful Shadows in CSS](https://www.joshwcomeau.com/css/designing-shadows/), [Concentric Border Radius](https://jakub.kr/work/concentric-border-radius), [@PixelJanitor](https://threadreaderapp.com/thread/1623358514440859649)
+
+---
+
+## Output Format
+
+When reviewing files, output findings as:
+
+```
+file:line - [rule-id] description of issue
+
+Example:
+components/modal/index.tsx:45 - [timing-under-300ms] Exit animation 400ms exceeds 300ms limit
+components/button/styles.module.css:12 - [physics-active-state] Missing :active transform
+components/drawer/index.tsx:23 - [spring-for-gestures] Drag interaction using easing instead of spring
+```
+
+## Summary Table
+
+After findings, output a summary:
+
+| Rule | Count | Severity |
+|------|-------|----------|
+| `timing-under-300ms` | 2 | HIGH |
+| `physics-active-state` | 3 | MEDIUM |
+| `exit-requires-wrapper` | 1 | HIGH |
+
+## References
+
+- [The Illusion of Life: Disney Animation](https://www.amazon.com/Illusion-Life-Disney-Animation/dp/0786860707)
+- [Apple WWDC23: Animate with Springs](https://developer.apple.com/videos/play/wwdc2023/10158)
+- [Motion Documentation](https://motion.dev)
+- [The Beauty of Bezier Curves - Freya Holmer](https://www.youtube.com/watch?v=aVwxzDHniEw)
+- [MDN Pseudo-elements Reference](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-elements)
+- [View Transitions API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API)
+- [Web Audio API Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API)
+- [prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
+- [SVG Line Element](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/line)
+- [ResizeObserver - MDN](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver)
+- [Laws of UX](https://lawsofux.com/) by Jon Yablonski
+- [ForesightJS](https://foresightjs.com)
+- [Next.js Prefetching Docs](https://nextjs.org/docs/app/guides/prefetching)
+- [Inter Typeface](https://rsms.me/inter/)
+- [MDN font-feature-settings](https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings)
+- [MDN font-variant-numeric](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric)
+- [Designing Beautiful Shadows in CSS - Josh W. Comeau](https://www.joshwcomeau.com/css/designing-shadows/)
+- [Concentric Border Radius](https://jakub.kr/work/concentric-border-radius)
+- [Nested Rounded Corners](https://www.ondrejkonecny.com/blog/nested-rounded-corners/)
+- [MDN text-wrap](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap)

--- a/.claude/skills/userinterface-wiki/SKILL.md
+++ b/.claude/skills/userinterface-wiki/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: userinterface-wiki
+description: UI/UX best practices for web interfaces. Use when reviewing animations, CSS, audio, typography, UX patterns, prefetching, or icon implementations. Covers 11 categories from animation principles to typography. Outputs file:line findings.
+license: MIT
+metadata:
+  author: raphael-salaja
+  version: "3.0.0"
+---
+
+# User Interface Wiki
+
+Comprehensive UI/UX best practices guide for web interfaces. Contains 152 rules across 12 categories, prioritized by impact to guide automated code review and generation.
+
+## When to Apply
+
+Reference these guidelines when:
+- Implementing or reviewing animations (CSS transitions, Motion/Framer Motion)
+- Choosing between springs, easing curves, or no animation
+- Working with AnimatePresence and exit animations
+- Writing CSS with pseudo-elements or View Transitions API
+- Adding audio feedback or procedural sound to UI
+- Building morphing icon components
+- Animating container width/height with dynamic content
+- Designing UI that respects cognitive psychology (Fitts's, Hick's, Miller's laws)
+- Implementing predictive prefetching for perceived performance
+- Setting up typography, OpenType features, or numeric formatting
+
+## Rule Categories by Priority
+
+| Priority | Category | Impact | Prefixes |
+|----------|----------|--------|----------|
+| 1 | Animation Principles | CRITICAL | `timing-`, `physics-`, `staging-` |
+| 2 | Timing Functions | HIGH | `spring-`, `easing-`, `duration-`, `none-` |
+| 3 | Exit Animations | HIGH | `exit-`, `presence-`, `mode-`, `nested-` |
+| 4 | CSS Pseudo Elements | MEDIUM | `pseudo-`, `transition-`, `native-` |
+| 5 | Audio Feedback | MEDIUM | `a11y-`, `appropriate-`, `impl-`, `weight-` |
+| 6 | Sound Synthesis | MEDIUM | `context-`, `envelope-`, `design-`, `param-` |
+| 7 | Morphing Icons | LOW | `morphing-` |
+| 8 | Container Animation | MEDIUM | `container-` |
+| 9 | Laws of UX | HIGH | `ux-` |
+| 10 | Predictive Prefetching | MEDIUM | `prefetch-` |
+| 11 | Typography | MEDIUM | `type-` |
+| 12 | Visual Design | HIGH | `visual-` |
+
+## Quick Reference
+
+### 1. Animation Principles (CRITICAL)
+
+- `timing-under-300ms` - User animations must complete within 300ms
+- `timing-consistent` - Similar elements use identical timing values
+- `timing-no-entrance-context-menu` - Context menus: no entrance animation, exit only
+- `easing-natural-decay` - Use exponential ramps for natural decay, not linear
+- `easing-no-linear-motion` - Linear easing only for progress indicators
+- `physics-active-state` - Interactive elements need :active scale transform
+- `physics-subtle-deformation` - Squash/stretch in 0.95-1.05 range
+- `physics-spring-for-overshoot` - Springs for overshoot-and-settle, not easing
+- `physics-no-excessive-stagger` - Stagger delays under 50ms per item
+- `staging-one-focal-point` - One prominent animation at a time
+- `staging-dim-background` - Dim modal/dialog backgrounds
+- `staging-z-index-hierarchy` - Animated elements respect z-index layers
+
+### 2. Timing Functions (HIGH)
+
+- `spring-for-gestures` - Gesture-driven motion (drag, flick) must use springs
+- `spring-for-interruptible` - Interruptible motion must use springs
+- `spring-preserves-velocity` - Springs preserve input energy on release
+- `spring-params-balanced` - Avoid excessive oscillation in spring params
+- `easing-for-state-change` - System state changes use easing curves
+- `easing-entrance-ease-out` - Entrances use ease-out
+- `easing-exit-ease-in` - Exits use ease-in
+- `easing-transition-ease-in-out` - View transitions use ease-in-out
+- `easing-linear-only-progress` - Linear only for progress/time representation
+- `duration-press-hover` - Press/hover: 120-180ms
+- `duration-small-state` - Small state changes: 180-260ms
+- `duration-max-300ms` - User-initiated max 300ms
+- `duration-shorten-before-curve` - Fix slow feel with shorter duration, not curve
+- `none-high-frequency` - No animation for high-frequency interactions
+- `none-keyboard-navigation` - Keyboard navigation instant, no animation
+- `none-context-menu-entrance` - Context menus: no entrance, exit only
+
+### 3. Exit Animations (HIGH)
+
+- `exit-requires-wrapper` - Conditional motion elements need AnimatePresence wrapper
+- `exit-prop-required` - Elements in AnimatePresence need exit prop
+- `exit-key-required` - Dynamic lists need unique keys, not index
+- `exit-matches-initial` - Exit mirrors initial for symmetry
+- `presence-hook-in-child` - useIsPresent in child, not parent
+- `presence-safe-to-remove` - Call safeToRemove after async cleanup
+- `presence-disable-interactions` - Disable interactions on exiting elements
+- `mode-wait-doubles-duration` - Mode "wait" doubles duration; halve timing
+- `mode-sync-layout-conflict` - Mode "sync" causes layout conflicts
+- `mode-pop-layout-for-lists` - Use popLayout for list reordering
+- `nested-propagate-required` - Nested AnimatePresence needs propagate prop
+- `nested-consistent-timing` - Coordinate parent-child exit durations
+
+### 4. CSS Pseudo Elements (MEDIUM)
+
+- `pseudo-content-required` - ::before/::after need content property
+- `pseudo-over-dom-node` - Pseudo-elements over extra DOM nodes for decoration
+- `pseudo-position-relative-parent` - Parent needs position: relative
+- `pseudo-z-index-layering` - Z-index for correct pseudo-element layering
+- `pseudo-hit-target-expansion` - Negative inset for larger hit targets
+- `pseudo-marker-styling` - Use ::marker for custom list bullet styles
+- `pseudo-first-line-styling` - Use ::first-line for typographic treatments
+- `transition-name-required` - View transitions need view-transition-name
+- `transition-name-unique` - Each transition name unique during transition
+- `transition-name-cleanup` - Remove transition name after completion
+- `transition-over-js-library` - Prefer View Transitions API over JS libraries
+- `transition-style-pseudo-elements` - Style ::view-transition-group for custom animations
+- `native-backdrop-styling` - Use ::backdrop for dialog backgrounds
+- `native-placeholder-styling` - Use ::placeholder for input styling
+- `native-selection-styling` - Use ::selection for text selection styling
+
+### 5. Audio Feedback (MEDIUM)
+
+- `a11y-visual-equivalent` - Every sound must have a visual equivalent
+- `a11y-toggle-setting` - Provide toggle to disable sounds
+- `a11y-reduced-motion-check` - Respect prefers-reduced-motion for sound
+- `a11y-volume-control` - Allow independent volume adjustment
+- `appropriate-no-high-frequency` - No sound on typing or keyboard nav
+- `appropriate-confirmations-only` - Sound for payments, uploads, submissions
+- `appropriate-errors-warnings` - Sound for errors that can't be overlooked
+- `appropriate-no-decorative` - No sound on hover or decorative moments
+- `appropriate-no-punishing` - Inform, don't punish with harsh sounds
+- `impl-preload-audio` - Preload audio files to avoid delay
+- `impl-default-subtle` - Default volume subtle (0.3), not loud
+- `impl-reset-current-time` - Reset currentTime before replay
+- `weight-match-action` - Sound weight matches action importance
+- `weight-duration-matches-action` - Sound duration matches action duration
+
+### 6. Sound Synthesis (MEDIUM)
+
+- `context-reuse-single` - Reuse single AudioContext, don't create per sound
+- `context-resume-suspended` - Resume suspended AudioContext before playing
+- `context-cleanup-nodes` - Disconnect audio nodes after playback
+- `envelope-exponential-decay` - Exponential ramps for natural decay
+- `envelope-no-zero-target` - Exponential ramps target 0.001, not 0
+- `envelope-set-initial-value` - Set initial value before ramping
+- `design-noise-for-percussion` - Filtered noise for clicks/taps
+- `design-oscillator-for-tonal` - Oscillators with pitch sweep for tonal sounds
+- `design-filter-for-character` - Bandpass filter to shape percussive sounds
+- `param-click-duration` - Click sounds: 5-15ms duration
+- `param-filter-frequency-range` - Click filter: 3000-6000Hz
+- `param-reasonable-gain` - Gain under 1.0 to prevent clipping
+- `param-q-value-range` - Filter Q: 2-5 for focused but natural
+
+### 7. Morphing Icons (LOW)
+
+- `morphing-three-lines` - Every icon uses exactly 3 SVG lines
+- `morphing-use-collapsed` - Unused lines use collapsed constant
+- `morphing-consistent-viewbox` - All icons share same viewBox (14x14)
+- `morphing-group-variants` - Rotational variants share group and base lines
+- `morphing-spring-rotation` - Spring physics for grouped icon rotation
+- `morphing-reduced-motion` - Respect prefers-reduced-motion
+- `morphing-jump-non-grouped` - Instant rotation jump between non-grouped icons
+- `morphing-strokelinecap-round` - Round stroke line caps
+- `morphing-aria-hidden` - Icon SVGs are aria-hidden
+
+### 8. Container Animation (MEDIUM)
+
+- `container-two-div-pattern` - Outer animated div, inner measured div; never same element
+- `container-guard-initial-zero` - Guard bounds === 0 on initial render, fall back to "auto"
+- `container-use-resize-observer` - Use ResizeObserver for measurement, not getBoundingClientRect
+- `container-overflow-hidden` - Set overflow: hidden on animated container during transitions
+- `container-no-excessive-use` - Use sparingly: buttons, accordions, interactive elements
+- `container-callback-ref` - Use callback ref (not useRef) for measurement hooks
+- `container-transition-delay` - Add small delay for natural catching-up feel
+
+### 9. Laws of UX (HIGH)
+
+- `ux-fitts-target-size` - Size interactive targets for easy clicking (min 32px)
+- `ux-fitts-hit-area` - Expand hit areas with invisible padding or pseudo-elements
+- `ux-hicks-minimize-choices` - Minimize choices to reduce decision time
+- `ux-millers-chunking` - Chunk data into groups of 5-9 for scannability
+- `ux-doherty-under-400ms` - Respond within 400ms to feel instant
+- `ux-doherty-perceived-speed` - Fake speed with skeletons, optimistic UI, progress indicators
+- `ux-postels-accept-messy-input` - Accept messy input, output clean data
+- `ux-progressive-disclosure` - Show what matters now, reveal complexity later
+- `ux-jakobs-familiar-patterns` - Use familiar UI patterns users know from other sites
+- `ux-aesthetic-usability` - Visual polish increases perceived usability
+- `ux-proximity-grouping` - Group related elements spatially with tighter spacing
+- `ux-similarity-consistency` - Similar elements should look alike
+- `ux-common-region-boundaries` - Use boundaries to group related content
+- `ux-von-restorff-emphasis` - Make important elements visually distinct
+- `ux-serial-position` - Place key items first or last in sequences
+- `ux-peak-end-finish-strong` - End experiences with clear success states
+- `ux-teslers-complexity` - Move complexity to the system, not the user
+- `ux-goal-gradient-progress` - Show progress toward completion
+- `ux-zeigarnik-show-incomplete` - Show incomplete state to drive completion
+- `ux-pragnanz-simplify` - Simplify complex visuals into clear forms
+- `ux-pareto-prioritize-features` - Prioritize the critical 20% of features
+- `ux-cognitive-load-reduce` - Minimize extraneous cognitive load
+- `ux-uniform-connectedness` - Visually connect related elements with lines or frames
+
+### 10. Predictive Prefetching (MEDIUM)
+
+- `prefetch-trajectory-over-hover` - Trajectory prediction over hover; reclaims 100-200ms
+- `prefetch-not-everything` - Prefetch by intent, not viewport; avoid wasted bandwidth
+- `prefetch-hit-slop` - Use hitSlop to trigger predictions earlier
+- `prefetch-touch-fallback` - Fall back gracefully on touch devices (no cursor)
+- `prefetch-keyboard-tab` - Prefetch on keyboard navigation when focus approaches
+- `prefetch-use-selectively` - Use predictive prefetching where latency is noticeable
+
+### 11. Typography (MEDIUM)
+
+- `type-tabular-nums-for-data` - Tabular numbers for columns, dashboards, pricing
+- `type-oldstyle-nums-for-prose` - Oldstyle numbers blend into body text
+- `type-slashed-zero` - Slashed zero in code-adjacent UIs
+- `type-opentype-contextual-alternates` - Keep calt enabled for contextual glyph adjustment
+- `type-disambiguation-stylistic-set` - Enable ss02 to distinguish I/l/1 and 0/O
+- `type-optical-sizing-auto` - Leave font-optical-sizing auto for size-adaptive glyphs
+- `type-antialiased-on-retina` - Antialiased font smoothing on retina displays
+- `type-text-wrap-balance-headings` - text-wrap: balance on headings for even lines
+- `type-underline-offset` - Offset underlines below descenders
+- `type-no-font-synthesis` - Disable font-synthesis to prevent faux bold/italic
+- `type-font-display-swap` - Use font-display: swap to avoid invisible text during load
+- `type-variable-weight-continuous` - Use continuous weight values (100-900) with variable fonts
+- `type-text-wrap-pretty` - text-wrap: pretty for body text to reduce orphans
+- `type-justify-with-hyphens` - Pair text-align: justify with hyphens: auto
+- `type-letter-spacing-uppercase` - Add letter-spacing to uppercase and small-caps text
+- `type-proper-fractions` - Use diagonal-fractions for proper typographic fractions
+
+### 12. Visual Design (HIGH)
+
+- `visual-concentric-radius` - Inner radius = outer radius minus padding for nested elements
+- `visual-layered-shadows` - Layer multiple shadows for realistic depth
+- `visual-shadow-direction` - All shadows share same offset direction (single light source)
+- `visual-no-pure-black-shadow` - Use neutral colors, not pure black, for shadows
+- `visual-shadow-matches-elevation` - Shadow size indicates elevation in consistent scale
+- `visual-animate-shadow-pseudo` - Animate shadow via pseudo-element opacity for performance
+- `visual-consistent-spacing-scale` - Use a consistent spacing scale, not arbitrary values
+- `visual-border-alpha-colors` - Semi-transparent borders adapt to any background
+- `visual-button-shadow-anatomy` - Six-layer shadow anatomy for polished buttons
+
+## How to Use
+
+Read individual rule files for detailed explanations and code examples:
+
+```
+rules/timing-under-300ms.md
+rules/spring-for-gestures.md
+rules/ux-doherty-under-400ms.md
+rules/type-tabular-nums-for-data.md
+```
+
+Each rule file contains:
+- Brief explanation of why it matters
+- Incorrect code example with explanation
+- Correct code example with explanation
+
+## Full Compiled Document
+
+For the complete guide with all rules expanded: `AGENTS.md`

--- a/.claude/skills/userinterface-wiki/rules/_sections.md
+++ b/.claude/skills/userinterface-wiki/rules/_sections.md
@@ -1,0 +1,66 @@
+# Sections
+
+This file defines all sections, their ordering, impact levels, and descriptions.
+The section ID (in parentheses) is the filename prefix used to group rules.
+
+---
+
+## 1. Animation Principles (timing, physics, staging)
+
+**Impact:** CRITICAL
+**Description:** Disney's 12 principles adapted for web. Timing, physics, and staging rules ensure animations feel natural and purposeful. Violations here produce the most noticeable quality issues.
+
+## 2. Timing Functions (spring, easing, duration, none)
+
+**Impact:** HIGH
+**Description:** Choosing the right timing function—spring, easing curve, or no animation—based on whether motion is user-driven, system-driven, or high-frequency.
+
+## 3. Exit Animations (exit, presence, mode, nested)
+
+**Impact:** HIGH
+**Description:** AnimatePresence and exit animation patterns in Motion/Framer Motion. Correct usage prevents layout shifts, stale interactions, and orphaned elements.
+
+## 4. CSS Pseudo Elements (pseudo, transition, native)
+
+**Impact:** MEDIUM
+**Description:** Leveraging ::before, ::after, View Transitions API, and native pseudo-elements (::backdrop, ::placeholder, ::selection) to reduce DOM nodes and improve transitions.
+
+## 5. Audio Feedback (a11y, appropriate, impl, weight)
+
+**Impact:** MEDIUM
+**Description:** When and how to use sound in UI. Covers accessibility, appropriateness heuristics, implementation patterns, and matching sound weight to action importance.
+
+## 6. Sound Synthesis (context, envelope, design, param)
+
+**Impact:** MEDIUM
+**Description:** Web Audio API best practices for procedural sound generation. Covers AudioContext management, envelope shaping, sound design patterns, and parameter ranges.
+
+## 7. Morphing Icons (morphing)
+
+**Impact:** LOW
+**Description:** Building icon components that morph between any two icons through SVG line transformation. All icons share a 3-line structure enabling seamless transitions.
+
+## 8. Container Animation (container)
+
+**Impact:** MEDIUM
+**Description:** Animating container width and height using a measure-and-animate pattern with ResizeObserver and Motion. The two-div pattern separates measurement from animation to avoid feedback loops.
+
+## 9. Laws of UX (ux)
+
+**Impact:** HIGH
+**Description:** Psychological principles behind interfaces that feel right. Covers Fitts's Law (target sizing), Hick's Law (choice reduction), Miller's Law (chunking), Doherty Threshold (response time), and Postel's Law (input tolerance).
+
+## 10. Predictive Prefetching (prefetch)
+
+**Impact:** MEDIUM
+**Description:** Loading content before the user clicks by analyzing cursor trajectory, reducing perceived latency by 100-200ms. Covers trajectory vs hover vs click strategies and device-aware fallbacks.
+
+## 11. Typography (type)
+
+**Impact:** MEDIUM
+**Description:** CSS font and text properties most developers overlook. OpenType features, numeric variants, variable font axes, text rendering, wrapping, and decoration controls that make typography feel considered.
+
+## 12. Visual Design (visual)
+
+**Impact:** HIGH
+**Description:** CSS design fundamentals that compound into visual polish. Concentric border radius, layered shadows, consistent spacing scales, and alpha borders. Small details that separate considered interfaces from default ones.

--- a/.claude/skills/userinterface-wiki/rules/_template.md
+++ b/.claude/skills/userinterface-wiki/rules/_template.md
@@ -1,0 +1,24 @@
+---
+title: Rule Title Here
+impact: MEDIUM
+impactDescription: Optional description of impact
+tags: tag1, tag2
+---
+
+## Rule Title Here
+
+Brief explanation of the rule and why it matters.
+
+**Incorrect (description of what's wrong):**
+
+```tsx
+// Bad code example here
+```
+
+**Correct (description of what's right):**
+
+```tsx
+// Good code example here
+```
+
+Reference: [Link to documentation or resource](https://example.com)

--- a/.claude/skills/userinterface-wiki/rules/a11y-reduced-motion-check.md
+++ b/.claude/skills/userinterface-wiki/rules/a11y-reduced-motion-check.md
@@ -1,0 +1,30 @@
+---
+title: Respect prefers-reduced-motion for Sound
+impact: HIGH
+tags: a11y, reduced-motion, sound
+---
+
+## Respect prefers-reduced-motion for Sound
+
+Respect prefers-reduced-motion as proxy for sound sensitivity.
+
+**Incorrect (ignores preference):**
+
+```tsx
+function playSound(name: string) {
+  audio.play();
+}
+```
+
+**Correct (checks preference):**
+
+```tsx
+function playSound(name: string) {
+  const prefersReducedMotion = window.matchMedia(
+    "(prefers-reduced-motion: reduce)"
+  ).matches;
+  
+  if (prefersReducedMotion) return;
+  audio.play();
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/a11y-toggle-setting.md
+++ b/.claude/skills/userinterface-wiki/rules/a11y-toggle-setting.md
@@ -1,0 +1,30 @@
+---
+title: Toggle Setting to Disable Sounds
+impact: HIGH
+tags: a11y, settings, toggle
+---
+
+## Toggle Setting to Disable Sounds
+
+Provide explicit toggle to disable sounds in settings.
+
+**Incorrect (no way to disable):**
+
+```tsx
+function App() {
+  return <SoundProvider>{children}</SoundProvider>;
+}
+```
+
+**Correct (toggle available):**
+
+```tsx
+function App() {
+  const { soundEnabled } = usePreferences();
+  return (
+    <SoundProvider enabled={soundEnabled}>
+      {children}
+    </SoundProvider>
+  );
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/a11y-visual-equivalent.md
+++ b/.claude/skills/userinterface-wiki/rules/a11y-visual-equivalent.md
@@ -1,0 +1,36 @@
+---
+title: Visual Equivalent for Every Sound
+impact: HIGH
+tags: a11y, visual, sound
+---
+
+## Visual Equivalent for Every Sound
+
+Every audio cue must have a visual equivalent; sound never replaces visual feedback.
+
+**Incorrect (sound without visual):**
+
+```tsx
+function SubmitButton({ onClick }) {
+  const handleClick = () => {
+    playSound("success");
+    onClick();
+  };
+}
+```
+
+**Correct (sound with visual):**
+
+```tsx
+function SubmitButton({ onClick }) {
+  const [status, setStatus] = useState("idle");
+  
+  const handleClick = () => {
+    playSound("success");
+    setStatus("success");
+    onClick();
+  };
+  
+  return <button data-status={status}>Submit</button>;
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/a11y-volume-control.md
+++ b/.claude/skills/userinterface-wiki/rules/a11y-volume-control.md
@@ -1,0 +1,28 @@
+---
+title: Independent Volume Control
+impact: MEDIUM
+tags: a11y, volume, settings
+---
+
+## Independent Volume Control
+
+Allow volume adjustment independent of system volume.
+
+**Incorrect (always full volume):**
+
+```tsx
+function playSound() {
+  audio.volume = 1;
+  audio.play();
+}
+```
+
+**Correct (user-controlled volume):**
+
+```tsx
+function playSound() {
+  const { volume } = usePreferences();
+  audio.volume = volume;
+  audio.play();
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/appropriate-confirmations-only.md
+++ b/.claude/skills/userinterface-wiki/rules/appropriate-confirmations-only.md
@@ -1,0 +1,19 @@
+---
+title: Sound for Confirmations
+impact: MEDIUM
+tags: appropriate, confirmation, payment
+---
+
+## Sound for Confirmations
+
+Sound is appropriate for confirmations: payments, uploads, form submissions.
+
+**Correct:**
+
+```tsx
+async function handlePayment() {
+  await processPayment();
+  playSound("success");
+  showConfirmation();
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/appropriate-errors-warnings.md
+++ b/.claude/skills/userinterface-wiki/rules/appropriate-errors-warnings.md
@@ -1,0 +1,18 @@
+---
+title: Sound for Errors and Warnings
+impact: MEDIUM
+tags: appropriate, error, warning
+---
+
+## Sound for Errors and Warnings
+
+Sound is appropriate for errors and warnings that can't be overlooked.
+
+**Correct:**
+
+```tsx
+function handleError(error: Error) {
+  playSound("error");
+  showErrorToast(error.message);
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/appropriate-no-decorative.md
+++ b/.claude/skills/userinterface-wiki/rules/appropriate-no-decorative.md
@@ -1,0 +1,21 @@
+---
+title: No Decorative Sound
+impact: MEDIUM
+tags: appropriate, decorative, hover
+---
+
+## No Decorative Sound
+
+Do not add sound to decorative moments with no informational value.
+
+**Incorrect (hover sound):**
+
+```tsx
+function Card({ onHover }) {
+  return (
+    <div onMouseEnter={() => playSound("hover")}>
+      {children}
+    </div>
+  );
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/appropriate-no-high-frequency.md
+++ b/.claude/skills/userinterface-wiki/rules/appropriate-no-high-frequency.md
@@ -1,0 +1,28 @@
+---
+title: No Sound on High-Frequency Interactions
+impact: HIGH
+tags: appropriate, frequency, typing
+---
+
+## No Sound on High-Frequency Interactions
+
+Do not add sound to high-frequency interactions (typing, keyboard navigation).
+
+**Incorrect (sound on every keystroke):**
+
+```tsx
+function Input({ onChange }) {
+  const handleChange = (e) => {
+    playSound("keystroke");
+    onChange(e);
+  };
+}
+```
+
+**Correct (no sound on typing):**
+
+```tsx
+function Input({ onChange }) {
+  return <input onChange={onChange} />;
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/appropriate-no-punishing.md
+++ b/.claude/skills/userinterface-wiki/rules/appropriate-no-punishing.md
@@ -1,0 +1,27 @@
+---
+title: Informative Not Punishing Sound
+impact: MEDIUM
+tags: appropriate, error, tone
+---
+
+## Informative Not Punishing Sound
+
+Sound should inform, not punish; avoid harsh sounds for user mistakes.
+
+**Incorrect (harsh buzzer):**
+
+```tsx
+function ValidationError() {
+  playSound("loud-buzzer");
+  return <span>Invalid input</span>;
+}
+```
+
+**Correct (gentle alert):**
+
+```tsx
+function ValidationError() {
+  playSound("gentle-alert");
+  return <span>Invalid input</span>;
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/container-callback-ref.md
+++ b/.claude/skills/userinterface-wiki/rules/container-callback-ref.md
@@ -1,0 +1,31 @@
+---
+title: Use Callback Ref for Measurement
+impact: MEDIUM
+tags: container, ref, callback
+---
+
+## Use Callback Ref for Measurement
+
+Use a callback ref (not useRef) for measurement hooks so the observer attaches when the DOM node is ready.
+
+**Incorrect (useRef may be null on first effect):**
+
+```tsx
+const ref = useRef(null);
+useEffect(() => {
+  if (!ref.current) return;
+  observer.observe(ref.current);
+}, []);
+```
+
+**Correct (callback ref guarantees node):**
+
+```tsx
+const [element, setElement] = useState(null);
+const ref = useCallback((node) => setElement(node), []);
+useEffect(() => {
+  if (!element) return;
+  observer.observe(element);
+  return () => observer.disconnect();
+}, [element]);
+```

--- a/.claude/skills/userinterface-wiki/rules/container-guard-initial-zero.md
+++ b/.claude/skills/userinterface-wiki/rules/container-guard-initial-zero.md
@@ -1,0 +1,25 @@
+---
+title: Guard Against Zero on Initial Render
+impact: HIGH
+tags: container, measure, initial-render
+---
+
+## Guard Against Zero on Initial Render
+
+On initial render, measured bounds are 0. Guard against this to prevent animating from 0 to actual size.
+
+**Incorrect (animates from 0 on mount):**
+
+```tsx
+<motion.div animate={{ width: bounds.width }}>
+  <div ref={ref}>{children}</div>
+</motion.div>
+```
+
+**Correct (falls back to auto on first frame):**
+
+```tsx
+<motion.div animate={{ width: bounds.width > 0 ? bounds.width : "auto" }}>
+  <div ref={ref}>{children}</div>
+</motion.div>
+```

--- a/.claude/skills/userinterface-wiki/rules/container-no-excessive-use.md
+++ b/.claude/skills/userinterface-wiki/rules/container-no-excessive-use.md
@@ -1,0 +1,13 @@
+---
+title: Use Animated Bounds Sparingly
+impact: MEDIUM
+tags: container, performance, restraint
+---
+
+## Use Animated Bounds Sparingly
+
+Animated bounds is a subtle effect. Use it for buttons, accordions, and interactive elements — not everywhere.
+
+**Good use cases:** loading state buttons, expandable sections, accordions, FAQs, content reveals.
+
+**Bad use cases:** every container on the page, static layouts, elements that don't change size.

--- a/.claude/skills/userinterface-wiki/rules/container-overflow-hidden.md
+++ b/.claude/skills/userinterface-wiki/rules/container-overflow-hidden.md
@@ -1,0 +1,25 @@
+---
+title: Overflow Hidden on Animated Container
+impact: MEDIUM
+tags: container, overflow, clip
+---
+
+## Overflow Hidden on Animated Container
+
+Set overflow: hidden on the animated outer container to clip content during size transitions.
+
+**Incorrect (content overflows during animation):**
+
+```tsx
+<motion.div animate={{ height: bounds.height }}>
+  <div ref={ref}>{children}</div>
+</motion.div>
+```
+
+**Correct (clipped during transition):**
+
+```tsx
+<motion.div animate={{ height: bounds.height }} style={{ overflow: "hidden" }}>
+  <div ref={ref}>{children}</div>
+</motion.div>
+```

--- a/.claude/skills/userinterface-wiki/rules/container-transition-delay.md
+++ b/.claude/skills/userinterface-wiki/rules/container-transition-delay.md
@@ -1,0 +1,21 @@
+---
+title: Add Delay for Natural Container Transitions
+impact: LOW
+tags: container, delay, transition, natural
+---
+
+## Add Delay for Natural Container Transitions
+
+Add a small delay to container size animations so the transition feels like it's catching up to the content.
+
+**Correct:**
+
+```tsx
+<motion.div
+  animate={{ height: bounds.height }}
+  transition={{ duration: 0.2, delay: 0.05 }}
+  style={{ overflow: "hidden" }}
+>
+  <div ref={ref}>{children}</div>
+</motion.div>
+```

--- a/.claude/skills/userinterface-wiki/rules/container-two-div-pattern.md
+++ b/.claude/skills/userinterface-wiki/rules/container-two-div-pattern.md
@@ -1,0 +1,35 @@
+---
+title: Two-Div Pattern for Animated Bounds
+impact: HIGH
+tags: container, measure, motion
+---
+
+## Two-Div Pattern for Animated Bounds
+
+Use an outer animated div and an inner measured div. Never measure and animate the same element.
+
+**Incorrect (measure and animate same element — creates feedback loop):**
+
+```tsx
+function AnimatedContainer({ children }) {
+  const [ref, bounds] = useMeasure();
+  return (
+    <motion.div ref={ref} animate={{ height: bounds.height }}>
+      {children}
+    </motion.div>
+  );
+}
+```
+
+**Correct (separate measure and animate targets):**
+
+```tsx
+function AnimatedContainer({ children }) {
+  const [ref, bounds] = useMeasure();
+  return (
+    <motion.div animate={{ height: bounds.height }}>
+      <div ref={ref}>{children}</div>
+    </motion.div>
+  );
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/container-use-resize-observer.md
+++ b/.claude/skills/userinterface-wiki/rules/container-use-resize-observer.md
@@ -1,0 +1,48 @@
+---
+title: Use ResizeObserver for Measurement
+impact: MEDIUM
+tags: container, resize-observer, performance
+---
+
+## Use ResizeObserver for Measurement
+
+Use ResizeObserver to track element dimensions. It fires on resize without causing layout thrashing.
+
+**Incorrect (measuring on every render):**
+
+```tsx
+function useMeasure(ref) {
+  const [bounds, setBounds] = useState({ width: 0, height: 0 });
+  useEffect(() => {
+    if (ref.current) {
+      const rect = ref.current.getBoundingClientRect();
+      setBounds({ width: rect.width, height: rect.height });
+    }
+  });
+  return bounds;
+}
+```
+
+**Correct (ResizeObserver):**
+
+```tsx
+function useMeasure() {
+  const [element, setElement] = useState(null);
+  const [bounds, setBounds] = useState({ width: 0, height: 0 });
+  const ref = useCallback((node) => setElement(node), []);
+
+  useEffect(() => {
+    if (!element) return;
+    const observer = new ResizeObserver(([entry]) => {
+      setBounds({
+        width: entry.contentRect.width,
+        height: entry.contentRect.height,
+      });
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [element]);
+
+  return [ref, bounds];
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/context-cleanup-nodes.md
+++ b/.claude/skills/userinterface-wiki/rules/context-cleanup-nodes.md
@@ -1,0 +1,25 @@
+---
+title: Clean Up Audio Nodes After Playback
+impact: MEDIUM
+tags: context, cleanup, disconnect
+---
+
+## Clean Up Audio Nodes After Playback
+
+Disconnect and clean up audio nodes after playback.
+
+**Incorrect (nodes remain connected):**
+
+```ts
+source.start();
+```
+
+**Correct (cleaned up on end):**
+
+```ts
+source.start();
+source.onended = () => {
+  source.disconnect();
+  gain.disconnect();
+};
+```

--- a/.claude/skills/userinterface-wiki/rules/context-resume-suspended.md
+++ b/.claude/skills/userinterface-wiki/rules/context-resume-suspended.md
@@ -1,0 +1,28 @@
+---
+title: Resume Suspended AudioContext
+impact: HIGH
+tags: context, resume, suspended
+---
+
+## Resume Suspended AudioContext
+
+Check and resume suspended AudioContext before playing.
+
+**Incorrect (plays without checking):**
+
+```ts
+function playSound() {
+  const ctx = getAudioContext();
+}
+```
+
+**Correct (resumes if suspended):**
+
+```ts
+function playSound() {
+  const ctx = getAudioContext();
+  if (ctx.state === "suspended") {
+    ctx.resume();
+  }
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/context-reuse-single.md
+++ b/.claude/skills/userinterface-wiki/rules/context-reuse-single.md
@@ -1,0 +1,30 @@
+---
+title: Reuse Single AudioContext
+impact: HIGH
+tags: context, audio-context, singleton
+---
+
+## Reuse Single AudioContext
+
+Reuse a single AudioContext instance; do not create new ones per sound.
+
+**Incorrect (new context per call):**
+
+```ts
+function playSound() {
+  const ctx = new AudioContext();
+}
+```
+
+**Correct (singleton):**
+
+```ts
+let audioContext: AudioContext | null = null;
+
+function getAudioContext(): AudioContext {
+  if (!audioContext) {
+    audioContext = new AudioContext();
+  }
+  return audioContext;
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/design-filter-for-character.md
+++ b/.claude/skills/userinterface-wiki/rules/design-filter-for-character.md
@@ -1,0 +1,25 @@
+---
+title: Bandpass Filter for Sound Character
+impact: MEDIUM
+tags: design, filter, bandpass
+---
+
+## Bandpass Filter for Sound Character
+
+Apply bandpass filter to shape percussive sounds.
+
+**Incorrect (raw noise):**
+
+```ts
+source.connect(gain).connect(ctx.destination);
+```
+
+**Correct (filtered noise):**
+
+```ts
+const filter = ctx.createBiquadFilter();
+filter.type = "bandpass";
+filter.frequency.value = 4000;
+filter.Q.value = 3;
+source.connect(filter).connect(gain).connect(ctx.destination);
+```

--- a/.claude/skills/userinterface-wiki/rules/design-noise-for-percussion.md
+++ b/.claude/skills/userinterface-wiki/rules/design-noise-for-percussion.md
@@ -1,0 +1,26 @@
+---
+title: Noise for Percussive Sounds
+impact: MEDIUM
+tags: design, noise, percussion
+---
+
+## Noise for Percussive Sounds
+
+Use filtered noise for clicks/taps, not oscillators.
+
+**Incorrect (oscillator for click):**
+
+```ts
+const osc = ctx.createOscillator();
+osc.type = "sine";
+```
+
+**Correct (noise burst for click):**
+
+```ts
+const buffer = ctx.createBuffer(1, ctx.sampleRate * 0.008, ctx.sampleRate);
+const data = buffer.getChannelData(0);
+for (let i = 0; i < data.length; i++) {
+  data[i] = (Math.random() * 2 - 1) * Math.exp(-i / 50);
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/design-oscillator-for-tonal.md
+++ b/.claude/skills/userinterface-wiki/rules/design-oscillator-for-tonal.md
@@ -1,0 +1,22 @@
+---
+title: Oscillators for Tonal Sounds
+impact: MEDIUM
+tags: design, oscillator, tonal
+---
+
+## Oscillators for Tonal Sounds
+
+Use oscillators with pitch movement for tonal sounds (pops, confirmations).
+
+**Incorrect (static frequency):**
+
+```ts
+osc.frequency.value = 400;
+```
+
+**Correct (pitch sweep):**
+
+```ts
+osc.frequency.setValueAtTime(400, t);
+osc.frequency.exponentialRampToValueAtTime(600, t + 0.04);
+```

--- a/.claude/skills/userinterface-wiki/rules/duration-max-300ms.md
+++ b/.claude/skills/userinterface-wiki/rules/duration-max-300ms.md
@@ -1,0 +1,21 @@
+---
+title: Max 300ms for User Actions
+impact: HIGH
+tags: duration, max, user-action
+---
+
+## Max 300ms for User Actions
+
+User-initiated animations must not exceed 300ms.
+
+**Incorrect (exceeds limit):**
+
+```tsx
+<motion.div transition={{ duration: 0.5 }} />
+```
+
+**Correct (within limit):**
+
+```tsx
+<motion.div transition={{ duration: 0.25 }} />
+```

--- a/.claude/skills/userinterface-wiki/rules/duration-press-hover.md
+++ b/.claude/skills/userinterface-wiki/rules/duration-press-hover.md
@@ -1,0 +1,21 @@
+---
+title: Press and Hover 120-180ms
+impact: MEDIUM
+tags: duration, press, hover
+---
+
+## Press and Hover 120-180ms
+
+Press and hover interactions should use 120-180ms duration.
+
+**Incorrect (too slow):**
+
+```css
+.button:hover { transition: background-color 400ms; }
+```
+
+**Correct (appropriate duration):**
+
+```css
+.button:hover { transition: background-color 150ms; }
+```

--- a/.claude/skills/userinterface-wiki/rules/duration-shorten-before-curve.md
+++ b/.claude/skills/userinterface-wiki/rules/duration-shorten-before-curve.md
@@ -1,0 +1,21 @@
+---
+title: Shorten Duration Before Adjusting Curve
+impact: MEDIUM
+tags: duration, optimization
+---
+
+## Shorten Duration Before Adjusting Curve
+
+If animation feels slow, shorten duration before adjusting curve.
+
+**Incorrect (adjusting curve instead):**
+
+```css
+.element { transition: 400ms cubic-bezier(0, 0.9, 0.1, 1); }
+```
+
+**Correct (shorter duration):**
+
+```css
+.element { transition: 200ms ease-out; }
+```

--- a/.claude/skills/userinterface-wiki/rules/duration-small-state.md
+++ b/.claude/skills/userinterface-wiki/rules/duration-small-state.md
@@ -1,0 +1,15 @@
+---
+title: Small State Changes 180-260ms
+impact: MEDIUM
+tags: duration, state-change
+---
+
+## Small State Changes 180-260ms
+
+Small state changes should use 180-260ms duration.
+
+**Correct:**
+
+```css
+.toggle { transition: transform 200ms ease; }
+```

--- a/.claude/skills/userinterface-wiki/rules/easing-entrance-ease-out.md
+++ b/.claude/skills/userinterface-wiki/rules/easing-entrance-ease-out.md
@@ -1,0 +1,21 @@
+---
+title: Ease-Out for Entrances
+impact: HIGH
+tags: easing, entrance, ease-out
+---
+
+## Ease-Out for Entrances
+
+Entrances must use ease-out (arrive fast, settle gently).
+
+**Incorrect (ease-in for entrance):**
+
+```css
+.modal-enter { animation-timing-function: ease-in; }
+```
+
+**Correct (ease-out for entrance):**
+
+```css
+.modal-enter { animation-timing-function: ease-out; }
+```

--- a/.claude/skills/userinterface-wiki/rules/easing-exit-ease-in.md
+++ b/.claude/skills/userinterface-wiki/rules/easing-exit-ease-in.md
@@ -1,0 +1,21 @@
+---
+title: Ease-In for Exits
+impact: HIGH
+tags: easing, exit, ease-in
+---
+
+## Ease-In for Exits
+
+Exits must use ease-in (build momentum before departure).
+
+**Incorrect (ease-out for exit):**
+
+```css
+.modal-exit { animation-timing-function: ease-out; }
+```
+
+**Correct (ease-in for exit):**
+
+```css
+.modal-exit { animation-timing-function: ease-in; }
+```

--- a/.claude/skills/userinterface-wiki/rules/easing-for-state-change.md
+++ b/.claude/skills/userinterface-wiki/rules/easing-for-state-change.md
@@ -1,0 +1,27 @@
+---
+title: Easing for System State Changes
+impact: HIGH
+tags: easing, state-change, system
+---
+
+## Easing for System State Changes
+
+System-initiated state changes should use easing curves.
+
+**Incorrect (spring for announcement):**
+
+```tsx
+<motion.div
+  animate={{ y: 0 }}
+  transition={{ type: "spring" }}
+/>
+```
+
+**Correct (easing for announcement):**
+
+```tsx
+<motion.div
+  animate={{ y: 0 }}
+  transition={{ duration: 0.2, ease: "easeOut" }}
+/>
+```

--- a/.claude/skills/userinterface-wiki/rules/easing-linear-only-progress.md
+++ b/.claude/skills/userinterface-wiki/rules/easing-linear-only-progress.md
@@ -1,0 +1,21 @@
+---
+title: Linear Easing Only for Progress
+impact: MEDIUM
+tags: easing, linear, progress
+---
+
+## Linear Easing Only for Progress
+
+Linear easing only for progress bars and time representation.
+
+**Incorrect (linear for motion):**
+
+```css
+.card-slide { transition: transform 200ms linear; }
+```
+
+**Correct (linear for progress):**
+
+```css
+.progress-bar { transition: width 100ms linear; }
+```

--- a/.claude/skills/userinterface-wiki/rules/easing-natural-decay.md
+++ b/.claude/skills/userinterface-wiki/rules/easing-natural-decay.md
@@ -1,0 +1,22 @@
+---
+title: Exponential Ramps for Natural Decay
+impact: MEDIUM
+impactDescription: Linear ramps for decay produce abrupt, unnatural cutoffs; exponential ramps match perceptual expectations.
+tags: easing, decay, audio, animation
+---
+
+## Exponential Ramps for Natural Decay
+
+Use exponential ramps, not linear, for natural decay.
+
+**Incorrect (linear ramp):**
+
+```ts
+gain.gain.linearRampToValueAtTime(0, t + 0.05);
+```
+
+**Correct (exponential ramp):**
+
+```ts
+gain.gain.exponentialRampToValueAtTime(0.001, t + 0.05);
+```

--- a/.claude/skills/userinterface-wiki/rules/easing-no-linear-motion.md
+++ b/.claude/skills/userinterface-wiki/rules/easing-no-linear-motion.md
@@ -1,0 +1,22 @@
+---
+title: No Linear Easing for Motion
+impact: MEDIUM
+impactDescription: Linear easing for motion feels mechanical; reserve it for progress indicators where uniform speed is expected.
+tags: easing, linear, animation
+---
+
+## No Linear Easing for Motion
+
+Linear easing should only be used for progress indicators, not motion.
+
+**Incorrect (linear for motion):**
+
+```css
+.card { transition: transform 200ms linear; }
+```
+
+**Correct (linear for progress only):**
+
+```css
+.progress-bar { transition: width 100ms linear; }
+```

--- a/.claude/skills/userinterface-wiki/rules/easing-transition-ease-in-out.md
+++ b/.claude/skills/userinterface-wiki/rules/easing-transition-ease-in-out.md
@@ -1,0 +1,15 @@
+---
+title: Ease-In-Out for View Transitions
+impact: MEDIUM
+tags: easing, transition, ease-in-out
+---
+
+## Ease-In-Out for View Transitions
+
+View/mode transitions use ease-in-out for neutral attention.
+
+**Correct:**
+
+```css
+.page-transition { animation-timing-function: ease-in-out; }
+```

--- a/.claude/skills/userinterface-wiki/rules/envelope-exponential-decay.md
+++ b/.claude/skills/userinterface-wiki/rules/envelope-exponential-decay.md
@@ -1,0 +1,21 @@
+---
+title: Exponential Decay for Natural Sound
+impact: HIGH
+tags: envelope, decay, exponential
+---
+
+## Exponential Decay for Natural Sound
+
+Use exponential ramps for natural decay, not linear.
+
+**Incorrect (linear ramp):**
+
+```ts
+gain.gain.linearRampToValueAtTime(0, t + 0.05);
+```
+
+**Correct (exponential ramp):**
+
+```ts
+gain.gain.exponentialRampToValueAtTime(0.001, t + 0.05);
+```

--- a/.claude/skills/userinterface-wiki/rules/envelope-no-zero-target.md
+++ b/.claude/skills/userinterface-wiki/rules/envelope-no-zero-target.md
@@ -1,0 +1,21 @@
+---
+title: No Zero Target for Exponential Ramps
+impact: HIGH
+tags: envelope, exponential, zero
+---
+
+## No Zero Target for Exponential Ramps
+
+Exponential ramps cannot target 0; use 0.001 or similar small value.
+
+**Incorrect (targets zero):**
+
+```ts
+gain.gain.exponentialRampToValueAtTime(0, t + 0.05);
+```
+
+**Correct (targets near-zero):**
+
+```ts
+gain.gain.exponentialRampToValueAtTime(0.001, t + 0.05);
+```

--- a/.claude/skills/userinterface-wiki/rules/envelope-set-initial-value.md
+++ b/.claude/skills/userinterface-wiki/rules/envelope-set-initial-value.md
@@ -1,0 +1,22 @@
+---
+title: Set Initial Value Before Ramp
+impact: MEDIUM
+tags: envelope, initial, glitch
+---
+
+## Set Initial Value Before Ramp
+
+Set initial value before ramping to avoid glitches.
+
+**Incorrect (no initial value):**
+
+```ts
+gain.gain.exponentialRampToValueAtTime(0.001, t + 0.05);
+```
+
+**Correct (initial value set):**
+
+```ts
+gain.gain.setValueAtTime(0.3, t);
+gain.gain.exponentialRampToValueAtTime(0.001, t + 0.05);
+```

--- a/.claude/skills/userinterface-wiki/rules/exit-key-required.md
+++ b/.claude/skills/userinterface-wiki/rules/exit-key-required.md
@@ -1,0 +1,29 @@
+---
+title: Unique Keys in AnimatePresence Lists
+impact: HIGH
+tags: exit, key, list
+---
+
+## Unique Keys in AnimatePresence Lists
+
+Dynamic lists inside AnimatePresence must have unique keys.
+
+**Incorrect (index as key):**
+
+```tsx
+<AnimatePresence>
+  {items.map((item, index) => (
+    <motion.div key={index} exit={{ opacity: 0 }} />
+  ))}
+</AnimatePresence>
+```
+
+**Correct (stable unique key):**
+
+```tsx
+<AnimatePresence>
+  {items.map((item) => (
+    <motion.div key={item.id} exit={{ opacity: 0 }} />
+  ))}
+</AnimatePresence>
+```

--- a/.claude/skills/userinterface-wiki/rules/exit-matches-initial.md
+++ b/.claude/skills/userinterface-wiki/rules/exit-matches-initial.md
@@ -1,0 +1,29 @@
+---
+title: Exit Mirrors Initial for Symmetry
+impact: MEDIUM
+tags: exit, initial, symmetry
+---
+
+## Exit Mirrors Initial for Symmetry
+
+Exit animation should mirror initial for symmetry.
+
+**Incorrect (asymmetric exit):**
+
+```tsx
+<motion.div
+  initial={{ opacity: 0, y: 20 }}
+  animate={{ opacity: 1, y: 0 }}
+  exit={{ scale: 0 }}
+/>
+```
+
+**Correct (symmetric exit):**
+
+```tsx
+<motion.div
+  initial={{ opacity: 0, y: 20 }}
+  animate={{ opacity: 1, y: 0 }}
+  exit={{ opacity: 0, y: 20 }}
+/>
+```

--- a/.claude/skills/userinterface-wiki/rules/exit-prop-required.md
+++ b/.claude/skills/userinterface-wiki/rules/exit-prop-required.md
@@ -1,0 +1,33 @@
+---
+title: Exit Prop Required Inside AnimatePresence
+impact: HIGH
+tags: exit, prop, animate-presence
+---
+
+## Exit Prop Required Inside AnimatePresence
+
+Elements inside AnimatePresence should have exit prop defined.
+
+**Incorrect (missing exit):**
+
+```tsx
+<AnimatePresence>
+  {isOpen && (
+    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} />
+  )}
+</AnimatePresence>
+```
+
+**Correct (exit defined):**
+
+```tsx
+<AnimatePresence>
+  {isOpen && (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+    />
+  )}
+</AnimatePresence>
+```

--- a/.claude/skills/userinterface-wiki/rules/exit-requires-wrapper.md
+++ b/.claude/skills/userinterface-wiki/rules/exit-requires-wrapper.md
@@ -1,0 +1,27 @@
+---
+title: AnimatePresence Wrapper Required
+impact: HIGH
+tags: exit, animate-presence, wrapper
+---
+
+## AnimatePresence Wrapper Required
+
+Conditional motion elements must be wrapped in AnimatePresence.
+
+**Incorrect (no wrapper):**
+
+```tsx
+{isVisible && (
+  <motion.div exit={{ opacity: 0 }} />
+)}
+```
+
+**Correct (wrapped):**
+
+```tsx
+<AnimatePresence>
+  {isVisible && (
+    <motion.div exit={{ opacity: 0 }} />
+  )}
+</AnimatePresence>
+```

--- a/.claude/skills/userinterface-wiki/rules/impl-default-subtle.md
+++ b/.claude/skills/userinterface-wiki/rules/impl-default-subtle.md
@@ -1,0 +1,21 @@
+---
+title: Subtle Default Volume
+impact: MEDIUM
+tags: impl, volume, default
+---
+
+## Subtle Default Volume
+
+Default volume should be subtle, not loud.
+
+**Incorrect (too loud):**
+
+```tsx
+const DEFAULT_VOLUME = 1.0;
+```
+
+**Correct (subtle):**
+
+```tsx
+const DEFAULT_VOLUME = 0.3;
+```

--- a/.claude/skills/userinterface-wiki/rules/impl-preload-audio.md
+++ b/.claude/skills/userinterface-wiki/rules/impl-preload-audio.md
@@ -1,0 +1,34 @@
+---
+title: Preload Audio Files
+impact: MEDIUM
+tags: impl, preload, performance
+---
+
+## Preload Audio Files
+
+Preload audio files to avoid playback delay.
+
+**Incorrect (loads on demand):**
+
+```tsx
+function playSound(name: string) {
+  const audio = new Audio(`/sounds/${name}.mp3`);
+  audio.play();
+}
+```
+
+**Correct (preloaded):**
+
+```tsx
+const sounds = {
+  success: new Audio("/sounds/success.mp3"),
+  error: new Audio("/sounds/error.mp3"),
+};
+
+Object.values(sounds).forEach(audio => audio.load());
+
+function playSound(name: keyof typeof sounds) {
+  sounds[name].currentTime = 0;
+  sounds[name].play();
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/impl-reset-current-time.md
+++ b/.claude/skills/userinterface-wiki/rules/impl-reset-current-time.md
@@ -1,0 +1,26 @@
+---
+title: Reset currentTime Before Replay
+impact: MEDIUM
+tags: impl, replay, current-time
+---
+
+## Reset currentTime Before Replay
+
+Reset audio currentTime before replay to allow rapid triggering.
+
+**Incorrect (won't replay if playing):**
+
+```tsx
+function playSound() {
+  audio.play();
+}
+```
+
+**Correct (reset before play):**
+
+```tsx
+function playSound() {
+  audio.currentTime = 0;
+  audio.play();
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/mode-pop-layout-for-lists.md
+++ b/.claude/skills/userinterface-wiki/rules/mode-pop-layout-for-lists.md
@@ -1,0 +1,25 @@
+---
+title: popLayout for List Reordering
+impact: MEDIUM
+tags: mode, pop-layout, list
+---
+
+## popLayout for List Reordering
+
+Use popLayout mode for list reordering animations.
+
+**Incorrect (default mode causes shifts):**
+
+```tsx
+<AnimatePresence>
+  {items.map(item => <ListItem key={item.id} />)}
+</AnimatePresence>
+```
+
+**Correct (popLayout prevents shifts):**
+
+```tsx
+<AnimatePresence mode="popLayout">
+  {items.map(item => <ListItem key={item.id} />)}
+</AnimatePresence>
+```

--- a/.claude/skills/userinterface-wiki/rules/mode-sync-layout-conflict.md
+++ b/.claude/skills/userinterface-wiki/rules/mode-sync-layout-conflict.md
@@ -1,0 +1,29 @@
+---
+title: Mode "sync" Causes Layout Conflicts
+impact: MEDIUM
+tags: mode, sync, layout
+---
+
+## Mode "sync" Causes Layout Conflicts
+
+Mode "sync" causes layout conflicts; position exiting elements absolutely.
+
+**Incorrect (sync with layout competition):**
+
+```tsx
+<AnimatePresence mode="sync">
+  {items.map(item => (
+    <motion.div exit={{ opacity: 0 }}>{item}</motion.div>
+  ))}
+</AnimatePresence>
+```
+
+**Correct (popLayout instead):**
+
+```tsx
+<AnimatePresence mode="popLayout">
+  {items.map(item => (
+    <motion.div exit={{ opacity: 0 }}>{item}</motion.div>
+  ))}
+</AnimatePresence>
+```

--- a/.claude/skills/userinterface-wiki/rules/mode-wait-doubles-duration.md
+++ b/.claude/skills/userinterface-wiki/rules/mode-wait-doubles-duration.md
@@ -1,0 +1,25 @@
+---
+title: Mode "wait" Doubles Duration
+impact: MEDIUM
+tags: mode, wait, duration
+---
+
+## Mode "wait" Doubles Duration
+
+Mode "wait" nearly doubles animation duration; adjust timing accordingly.
+
+**Incorrect (too slow with wait):**
+
+```tsx
+<AnimatePresence mode="wait">
+  <motion.div transition={{ duration: 0.3 }} />
+</AnimatePresence>
+```
+
+**Correct (halved timing):**
+
+```tsx
+<AnimatePresence mode="wait">
+  <motion.div transition={{ duration: 0.15 }} />
+</AnimatePresence>
+```

--- a/.claude/skills/userinterface-wiki/rules/morphing-aria-hidden.md
+++ b/.claude/skills/userinterface-wiki/rules/morphing-aria-hidden.md
@@ -1,0 +1,21 @@
+---
+title: Aria Hidden on Icon SVGs
+impact: LOW
+tags: morphing, a11y, aria
+---
+
+## Aria Hidden on Icon SVGs
+
+Icon SVGs should be aria-hidden since they're decorative.
+
+**Incorrect (no aria attribute):**
+
+```tsx
+<svg width={size} height={size}>...</svg>
+```
+
+**Correct (aria-hidden):**
+
+```tsx
+<svg width={size} height={size} aria-hidden="true">...</svg>
+```

--- a/.claude/skills/userinterface-wiki/rules/morphing-consistent-viewbox.md
+++ b/.claude/skills/userinterface-wiki/rules/morphing-consistent-viewbox.md
@@ -1,0 +1,23 @@
+---
+title: Consistent ViewBox Size
+impact: HIGH
+tags: morphing, viewbox, svg
+---
+
+## Consistent ViewBox Size
+
+All icons must use the same viewBox (14x14 recommended).
+
+**Incorrect (mixed scales):**
+
+```ts
+const icon1 = { lines: [{ x1: 2, y1: 7, x2: 12, y2: 7 }, ...] }; // 14x14
+const icon2 = { lines: [{ x1: 4, y1: 14, x2: 24, y2: 14 }, ...] }; // 28x28
+```
+
+**Correct (consistent scale):**
+
+```ts
+const VIEWBOX_SIZE = 14;
+const CENTER = 7;
+```

--- a/.claude/skills/userinterface-wiki/rules/morphing-group-variants.md
+++ b/.claude/skills/userinterface-wiki/rules/morphing-group-variants.md
@@ -1,0 +1,33 @@
+---
+title: Shared Group for Rotational Variants
+impact: HIGH
+tags: morphing, group, rotation
+---
+
+## Shared Group for Rotational Variants
+
+Icons that are rotational variants MUST share the same group and base lines.
+
+**Incorrect (different line definitions):**
+
+```ts
+const arrowRight = { lines: [{ x1: 2, y1: 7, x2: 12, y2: 7 }, ...] };
+const arrowDown = { lines: [{ x1: 7, y1: 2, x2: 7, y2: 12 }, ...] };
+```
+
+**Correct (shared base lines):**
+
+```ts
+const arrowLines: [IconLine, IconLine, IconLine] = [
+  { x1: 2, y1: 7, x2: 12, y2: 7 },
+  { x1: 7.5, y1: 2.5, x2: 12, y2: 7 },
+  { x1: 7.5, y1: 11.5, x2: 12, y2: 7 },
+];
+
+const icons = {
+  "arrow-right": { lines: arrowLines, rotation: 0, group: "arrow" },
+  "arrow-down": { lines: arrowLines, rotation: 90, group: "arrow" },
+  "arrow-left": { lines: arrowLines, rotation: 180, group: "arrow" },
+  "arrow-up": { lines: arrowLines, rotation: -90, group: "arrow" },
+};
+```

--- a/.claude/skills/userinterface-wiki/rules/morphing-jump-non-grouped.md
+++ b/.claude/skills/userinterface-wiki/rules/morphing-jump-non-grouped.md
@@ -1,0 +1,29 @@
+---
+title: Instant Jump for Non-Grouped Icons
+impact: MEDIUM
+tags: morphing, jump, group
+---
+
+## Instant Jump for Non-Grouped Icons
+
+When transitioning between icons NOT in the same group, rotation should jump instantly.
+
+**Incorrect (always animates rotation):**
+
+```tsx
+useEffect(() => {
+  rotation.set(definition.rotation ?? 0);
+}, [definition]);
+```
+
+**Correct (jumps when not grouped):**
+
+```tsx
+useEffect(() => {
+  if (shouldRotate) {
+    rotation.set(definition.rotation ?? 0);
+  } else {
+    rotation.jump(definition.rotation ?? 0);
+  }
+}, [definition, shouldRotate]);
+```

--- a/.claude/skills/userinterface-wiki/rules/morphing-reduced-motion.md
+++ b/.claude/skills/userinterface-wiki/rules/morphing-reduced-motion.md
@@ -1,0 +1,28 @@
+---
+title: Reduced Motion Support for Icons
+impact: MEDIUM
+tags: morphing, a11y, reduced-motion
+---
+
+## Reduced Motion Support for Icons
+
+Respect prefers-reduced-motion by disabling animations.
+
+**Incorrect (always animates):**
+
+```tsx
+function MorphingIcon({ icon }: Props) {
+  return <motion.line animate={...} transition={{ duration: 0.4 }} />;
+}
+```
+
+**Correct (respects preference):**
+
+```tsx
+function MorphingIcon({ icon }: Props) {
+  const reducedMotion = useReducedMotion() ?? false;
+  const activeTransition = reducedMotion ? { duration: 0 } : transition;
+  
+  return <motion.line animate={...} transition={activeTransition} />;
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/morphing-spring-rotation.md
+++ b/.claude/skills/userinterface-wiki/rules/morphing-spring-rotation.md
@@ -1,0 +1,23 @@
+---
+title: Spring Physics for Rotation
+impact: MEDIUM
+tags: morphing, spring, rotation
+---
+
+## Spring Physics for Rotation
+
+Rotation between grouped icons should use spring physics for natural motion.
+
+**Incorrect (duration-based rotation):**
+
+```tsx
+<motion.g animate={{ rotate: rotation }} transition={{ duration: 0.3 }} />
+```
+
+**Correct (spring rotation):**
+
+```tsx
+const rotation = useSpring(definition.rotation ?? 0, activeTransition);
+
+<motion.g style={{ rotate: rotation, transformOrigin: "center" }} />
+```

--- a/.claude/skills/userinterface-wiki/rules/morphing-strokelinecap-round.md
+++ b/.claude/skills/userinterface-wiki/rules/morphing-strokelinecap-round.md
@@ -1,0 +1,21 @@
+---
+title: Round Stroke Line Caps
+impact: LOW
+tags: morphing, stroke, svg
+---
+
+## Round Stroke Line Caps
+
+Lines should use strokeLinecap="round" for polished endpoints.
+
+**Incorrect (butt caps):**
+
+```tsx
+<motion.line strokeLinecap="butt" />
+```
+
+**Correct (round caps):**
+
+```tsx
+<motion.line strokeLinecap="round" />
+```

--- a/.claude/skills/userinterface-wiki/rules/morphing-three-lines.md
+++ b/.claude/skills/userinterface-wiki/rules/morphing-three-lines.md
@@ -1,0 +1,32 @@
+---
+title: Icons Must Use Exactly Three Lines
+impact: HIGH
+tags: morphing, svg, structure
+---
+
+## Icons Must Use Exactly Three Lines
+
+Every icon MUST use exactly 3 lines. No more, no fewer.
+
+**Incorrect (only 2 lines):**
+
+```ts
+const checkIcon = {
+  lines: [
+    { x1: 2, y1: 7.5, x2: 5.5, y2: 11 },
+    { x1: 5.5, y1: 11, x2: 12, y2: 3 },
+  ],
+};
+```
+
+**Correct (3 lines with collapsed):**
+
+```ts
+const checkIcon = {
+  lines: [
+    { x1: 2, y1: 7.5, x2: 5.5, y2: 11 },
+    { x1: 5.5, y1: 11, x2: 12, y2: 3 },
+    collapsed,
+  ],
+};
+```

--- a/.claude/skills/userinterface-wiki/rules/morphing-use-collapsed.md
+++ b/.claude/skills/userinterface-wiki/rules/morphing-use-collapsed.md
@@ -1,0 +1,33 @@
+---
+title: Use Collapsed Constant for Unused Lines
+impact: HIGH
+tags: morphing, collapsed, structure
+---
+
+## Use Collapsed Constant for Unused Lines
+
+Unused lines must use the collapsed constant, not omission or null.
+
+**Incorrect (null for unused):**
+
+```ts
+const minusIcon = {
+  lines: [
+    { x1: 2, y1: 7, x2: 12, y2: 7 },
+    null,
+    null,
+  ],
+};
+```
+
+**Correct (collapsed constant):**
+
+```ts
+const minusIcon = {
+  lines: [
+    { x1: 2, y1: 7, x2: 12, y2: 7 },
+    collapsed,
+    collapsed,
+  ],
+};
+```

--- a/.claude/skills/userinterface-wiki/rules/native-backdrop-styling.md
+++ b/.claude/skills/userinterface-wiki/rules/native-backdrop-styling.md
@@ -1,0 +1,27 @@
+---
+title: Use ::backdrop for Dialog Backgrounds
+impact: MEDIUM
+tags: native, backdrop, dialog
+---
+
+## Use ::backdrop for Dialog Backgrounds
+
+Use ::backdrop pseudo-element for dialog/popover backgrounds.
+
+**Incorrect (extra overlay node):**
+
+```tsx
+<>
+  <div className={styles.overlay} onClick={close} />
+  <dialog className={styles.dialog}>{children}</dialog>
+</>
+```
+
+**Correct (native ::backdrop):**
+
+```css
+dialog::backdrop {
+  background: var(--black-a6);
+  backdrop-filter: blur(4px);
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/native-placeholder-styling.md
+++ b/.claude/skills/userinterface-wiki/rules/native-placeholder-styling.md
@@ -1,0 +1,27 @@
+---
+title: Use ::placeholder for Input Styling
+impact: LOW
+tags: native, placeholder, input
+---
+
+## Use ::placeholder for Input Styling
+
+Use ::placeholder for input placeholder styling, not wrapper elements.
+
+**Incorrect (custom placeholder node):**
+
+```tsx
+<div className={styles.inputWrapper}>
+  {!value && <span className={styles.placeholder}>Enter text...</span>}
+  <input value={value} />
+</div>
+```
+
+**Correct (native ::placeholder):**
+
+```css
+input::placeholder {
+  color: var(--gray-9);
+  opacity: 1;
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/native-selection-styling.md
+++ b/.claude/skills/userinterface-wiki/rules/native-selection-styling.md
@@ -1,0 +1,18 @@
+---
+title: Use ::selection for Text Styling
+impact: LOW
+tags: native, selection, text
+---
+
+## Use ::selection for Text Styling
+
+Use ::selection for text selection styling.
+
+**Correct:**
+
+```css
+::selection {
+  background: var(--blue-a5);
+  color: var(--gray-12);
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/nested-consistent-timing.md
+++ b/.claude/skills/userinterface-wiki/rules/nested-consistent-timing.md
@@ -1,0 +1,25 @@
+---
+title: Coordinated Parent-Child Exit Timing
+impact: MEDIUM
+tags: nested, timing, exit
+---
+
+## Coordinated Parent-Child Exit Timing
+
+Parent and child exit durations should be coordinated.
+
+**Incorrect (parent too fast):**
+
+```tsx
+<motion.div exit={{ opacity: 0 }} transition={{ duration: 0.1 }}>
+  <motion.div exit={{ scale: 0 }} transition={{ duration: 0.5 }} />
+</motion.div>
+```
+
+**Correct (coordinated timing):**
+
+```tsx
+<motion.div exit={{ opacity: 0 }} transition={{ duration: 0.2 }}>
+  <motion.div exit={{ scale: 0 }} transition={{ duration: 0.15 }} />
+</motion.div>
+```

--- a/.claude/skills/userinterface-wiki/rules/nested-propagate-required.md
+++ b/.claude/skills/userinterface-wiki/rules/nested-propagate-required.md
@@ -1,0 +1,41 @@
+---
+title: Propagate Prop for Nested AnimatePresence
+impact: HIGH
+tags: nested, propagate, exit
+---
+
+## Propagate Prop for Nested AnimatePresence
+
+Nested AnimatePresence must use propagate prop for coordinated exits.
+
+**Incorrect (children vanish instantly):**
+
+```tsx
+<AnimatePresence>
+  {isOpen && (
+    <motion.div exit={{ opacity: 0 }}>
+      <AnimatePresence>
+        {items.map(item => (
+          <motion.div key={item.id} exit={{ scale: 0 }} />
+        ))}
+      </AnimatePresence>
+    </motion.div>
+  )}
+</AnimatePresence>
+```
+
+**Correct (propagate on both):**
+
+```tsx
+<AnimatePresence propagate>
+  {isOpen && (
+    <motion.div exit={{ opacity: 0 }}>
+      <AnimatePresence propagate>
+        {items.map(item => (
+          <motion.div key={item.id} exit={{ scale: 0 }} />
+        ))}
+      </AnimatePresence>
+    </motion.div>
+  )}
+</AnimatePresence>
+```

--- a/.claude/skills/userinterface-wiki/rules/none-context-menu-entrance.md
+++ b/.claude/skills/userinterface-wiki/rules/none-context-menu-entrance.md
@@ -1,0 +1,25 @@
+---
+title: No Entrance Animation for Context Menus
+impact: MEDIUM
+tags: none, context-menu, entrance
+---
+
+## No Entrance Animation for Context Menus
+
+Context menus should not animate on entrance (exit only).
+
+**Incorrect (entrance animation):**
+
+```tsx
+<motion.div
+  initial={{ opacity: 0, scale: 0.95 }}
+  animate={{ opacity: 1, scale: 1 }}
+  exit={{ opacity: 0 }}
+/>
+```
+
+**Correct (exit only):**
+
+```tsx
+<motion.div exit={{ opacity: 0, scale: 0.95 }} />
+```

--- a/.claude/skills/userinterface-wiki/rules/none-high-frequency.md
+++ b/.claude/skills/userinterface-wiki/rules/none-high-frequency.md
@@ -1,0 +1,29 @@
+---
+title: No Animation for High-Frequency Interactions
+impact: HIGH
+tags: none, high-frequency, performance
+---
+
+## No Animation for High-Frequency Interactions
+
+High-frequency interactions should have no animation.
+
+**Incorrect (animated on every keystroke):**
+
+```tsx
+function SearchInput() {
+  return (
+    <motion.div animate={{ scale: [1, 1.02, 1] }}>
+      <input onChange={handleSearch} />
+    </motion.div>
+  );
+}
+```
+
+**Correct (no animation):**
+
+```tsx
+function SearchInput() {
+  return <input onChange={handleSearch} />;
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/none-keyboard-navigation.md
+++ b/.claude/skills/userinterface-wiki/rules/none-keyboard-navigation.md
@@ -1,0 +1,32 @@
+---
+title: No Animation for Keyboard Navigation
+impact: MEDIUM
+tags: none, keyboard, a11y
+---
+
+## No Animation for Keyboard Navigation
+
+Keyboard navigation should be instant, no animation.
+
+**Incorrect (animated focus):**
+
+```tsx
+function Menu() {
+  return items.map(item => (
+    <motion.li
+      whileFocus={{ scale: 1.05 }}
+      transition={{ duration: 0.2 }}
+    />
+  ));
+}
+```
+
+**Correct (CSS focus-visible only):**
+
+```tsx
+function Menu() {
+  return items.map(item => (
+    <li className={styles.menuItem} />
+  ));
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/param-click-duration.md
+++ b/.claude/skills/userinterface-wiki/rules/param-click-duration.md
@@ -1,0 +1,21 @@
+---
+title: Click Duration 5-15ms
+impact: MEDIUM
+tags: param, click, duration
+---
+
+## Click Duration 5-15ms
+
+Click/tap sounds should be 5-15ms duration.
+
+**Incorrect (too long):**
+
+```ts
+const buffer = ctx.createBuffer(1, ctx.sampleRate * 0.1, ctx.sampleRate);
+```
+
+**Correct (appropriate duration):**
+
+```ts
+const buffer = ctx.createBuffer(1, ctx.sampleRate * 0.008, ctx.sampleRate);
+```

--- a/.claude/skills/userinterface-wiki/rules/param-filter-frequency-range.md
+++ b/.claude/skills/userinterface-wiki/rules/param-filter-frequency-range.md
@@ -1,0 +1,21 @@
+---
+title: Click Filter 3000-6000Hz
+impact: LOW
+tags: param, filter, frequency
+---
+
+## Click Filter 3000-6000Hz
+
+Bandpass filter for clicks should be 3000-6000Hz.
+
+**Incorrect (too low):**
+
+```ts
+filter.frequency.value = 500;
+```
+
+**Correct (crisp range):**
+
+```ts
+filter.frequency.value = 4000;
+```

--- a/.claude/skills/userinterface-wiki/rules/param-q-value-range.md
+++ b/.claude/skills/userinterface-wiki/rules/param-q-value-range.md
@@ -1,0 +1,21 @@
+---
+title: Filter Q Value 2-5
+impact: LOW
+tags: param, q-value, filter
+---
+
+## Filter Q Value 2-5
+
+Filter Q for clicks should be 2-5 for focused but not harsh sound.
+
+**Incorrect (too resonant):**
+
+```ts
+filter.Q.value = 15;
+```
+
+**Correct (balanced Q):**
+
+```ts
+filter.Q.value = 3;
+```

--- a/.claude/skills/userinterface-wiki/rules/param-reasonable-gain.md
+++ b/.claude/skills/userinterface-wiki/rules/param-reasonable-gain.md
@@ -1,0 +1,21 @@
+---
+title: Gain Under 1.0
+impact: MEDIUM
+tags: param, gain, clipping
+---
+
+## Gain Under 1.0
+
+Gain values should not exceed 1.0 to prevent clipping.
+
+**Incorrect (clipping):**
+
+```ts
+gain.gain.setValueAtTime(1.5, t);
+```
+
+**Correct (safe gain):**
+
+```ts
+gain.gain.setValueAtTime(0.3, t);
+```

--- a/.claude/skills/userinterface-wiki/rules/physics-active-state.md
+++ b/.claude/skills/userinterface-wiki/rules/physics-active-state.md
@@ -1,0 +1,23 @@
+---
+title: Active State Scale Transform
+impact: HIGH
+impactDescription: Missing active state makes interactive elements feel unresponsive and reduces tactile feedback.
+tags: physics, interaction, active-state
+---
+
+## Active State Scale Transform
+
+Interactive elements must have active/pressed state with scale transform.
+
+**Incorrect (no active state):**
+
+```css
+.button:hover { background: var(--gray-3); }
+/* Missing :active state */
+```
+
+**Correct (active state present):**
+
+```css
+.button:active { transform: scale(0.98); }
+```

--- a/.claude/skills/userinterface-wiki/rules/physics-no-excessive-stagger.md
+++ b/.claude/skills/userinterface-wiki/rules/physics-no-excessive-stagger.md
@@ -1,0 +1,22 @@
+---
+title: Stagger Under 50ms Per Item
+impact: MEDIUM
+impactDescription: Excessive stagger delays list readiness and feels sluggish; keep per-item delay minimal.
+tags: physics, stagger, list-animation
+---
+
+## Stagger Under 50ms Per Item
+
+Stagger delays must not exceed 50ms per item.
+
+**Incorrect (excessive stagger):**
+
+```tsx
+transition={{ staggerChildren: 0.15 }}
+```
+
+**Correct (reasonable stagger):**
+
+```tsx
+transition={{ staggerChildren: 0.03 }}
+```

--- a/.claude/skills/userinterface-wiki/rules/physics-spring-for-overshoot.md
+++ b/.claude/skills/userinterface-wiki/rules/physics-spring-for-overshoot.md
@@ -1,0 +1,23 @@
+---
+title: Springs for Overshoot and Settle
+impact: HIGH
+impactDescription: Easing cannot produce natural overshoot; springs are required for organic bounce-and-settle motion.
+tags: physics, spring, overshoot
+---
+
+## Springs for Overshoot and Settle
+
+Use springs (not easing) when overshoot-and-settle is needed.
+
+**Incorrect (easing for bounce):**
+
+```tsx
+<motion.div transition={{ duration: 0.3, ease: "easeOut" }} />
+// When element should bounce/settle
+```
+
+**Correct (spring physics):**
+
+```tsx
+<motion.div transition={{ type: "spring", stiffness: 500, damping: 30 }} />
+```

--- a/.claude/skills/userinterface-wiki/rules/physics-subtle-deformation.md
+++ b/.claude/skills/userinterface-wiki/rules/physics-subtle-deformation.md
@@ -1,0 +1,22 @@
+---
+title: Subtle Squash and Stretch
+impact: MEDIUM
+impactDescription: Excessive squash/stretch feels cartoonish and distracts from the interface; subtle deformation adds polish.
+tags: physics, squash-stretch, deformation
+---
+
+## Subtle Squash and Stretch
+
+Squash/stretch deformation must be subtle (0.95-1.05 range).
+
+**Incorrect (excessive deformation):**
+
+```tsx
+<motion.div whileTap={{ scale: 0.8 }} />
+```
+
+**Correct (subtle deformation):**
+
+```tsx
+<motion.div whileTap={{ scale: 0.98 }} />
+```

--- a/.claude/skills/userinterface-wiki/rules/prefetch-hit-slop.md
+++ b/.claude/skills/userinterface-wiki/rules/prefetch-hit-slop.md
@@ -1,0 +1,27 @@
+---
+title: Use hitSlop to Trigger Predictions Earlier
+impact: MEDIUM
+tags: prefetch, hit-slop, target
+---
+
+## Use hitSlop to Trigger Predictions Earlier
+
+Expand the invisible prediction area around elements with hitSlop to start loading sooner.
+
+**Incorrect (tight prediction area):**
+
+```tsx
+const { elementRef } = useForesight({
+  callback: () => prefetch(),
+  hitSlop: 0,
+});
+```
+
+**Correct (expanded prediction area):**
+
+```tsx
+const { elementRef } = useForesight({
+  callback: () => prefetch(),
+  hitSlop: 20,
+});
+```

--- a/.claude/skills/userinterface-wiki/rules/prefetch-keyboard-tab.md
+++ b/.claude/skills/userinterface-wiki/rules/prefetch-keyboard-tab.md
@@ -1,0 +1,19 @@
+---
+title: Prefetch on Keyboard Navigation
+impact: MEDIUM
+tags: prefetch, keyboard, tab, a11y
+---
+
+## Prefetch on Keyboard Navigation
+
+Monitor focus changes and prefetch when the user is a few tab stops away from a registered element.
+
+**Correct (tab-aware prefetching):**
+
+```tsx
+const { elementRef } = useForesight({
+  callback: () => router.prefetch("/settings"),
+  name: "settings-link",
+  // Tab prediction fires when focus approaches
+});
+```

--- a/.claude/skills/userinterface-wiki/rules/prefetch-not-everything.md
+++ b/.claude/skills/userinterface-wiki/rules/prefetch-not-everything.md
@@ -1,0 +1,22 @@
+---
+title: Prefetch by Intent, Not Viewport
+impact: HIGH
+tags: prefetch, viewport, intent, bundle-size
+---
+
+## Prefetch by Intent, Not Viewport
+
+Don't prefetch everything visible in the viewport. Prefetch based on user intent to avoid wasted bandwidth.
+
+**Incorrect (prefetch all visible links):**
+
+```tsx
+<Link href="/page" prefetch={true}>Page</Link>
+```
+
+**Correct (intent-based prefetching):**
+
+```tsx
+<Link href="/page" prefetch={false}>Page</Link>
+// Let trajectory/hover prediction handle it
+```

--- a/.claude/skills/userinterface-wiki/rules/prefetch-touch-fallback.md
+++ b/.claude/skills/userinterface-wiki/rules/prefetch-touch-fallback.md
@@ -1,0 +1,34 @@
+---
+title: Fall Back Gracefully on Touch Devices
+impact: MEDIUM
+tags: prefetch, touch, mobile, fallback
+---
+
+## Fall Back Gracefully on Touch Devices
+
+Touch devices have no cursor. Fall back to viewport or touch-start strategies automatically.
+
+**Incorrect (assumes cursor exists):**
+
+```tsx
+function PrefetchLink({ href, children }) {
+  return (
+    <Link
+      href={href}
+      onMouseMove={() => prefetch(href)}
+    >
+      {children}
+    </Link>
+  );
+}
+```
+
+**Correct (device-aware strategy):**
+
+```tsx
+const { elementRef } = useForesight({
+  callback: () => router.prefetch(href),
+  hitSlop: 20,
+});
+// Automatically falls back to touch-start on mobile
+```

--- a/.claude/skills/userinterface-wiki/rules/prefetch-trajectory-over-hover.md
+++ b/.claude/skills/userinterface-wiki/rules/prefetch-trajectory-over-hover.md
@@ -1,0 +1,32 @@
+---
+title: Trajectory Prediction Over Hover Prefetching
+impact: HIGH
+tags: prefetch, trajectory, hover, performance
+---
+
+## Trajectory Prediction Over Hover Prefetching
+
+Hover prefetching starts too late. Trajectory prediction fires while the cursor is still in motion, reclaiming 100-200ms.
+
+**Incorrect (waits for hover):**
+
+```tsx
+<Link
+  href="/about"
+  onMouseEnter={() => router.prefetch("/about")}
+>
+  About
+</Link>
+```
+
+**Correct (trajectory-based):**
+
+```tsx
+const { elementRef } = useForesight({
+  callback: () => router.prefetch("/about"),
+  hitSlop: 20,
+  name: "about-link",
+});
+
+<Link ref={elementRef} href="/about">About</Link>
+```

--- a/.claude/skills/userinterface-wiki/rules/prefetch-use-selectively.md
+++ b/.claude/skills/userinterface-wiki/rules/prefetch-use-selectively.md
@@ -1,0 +1,13 @@
+---
+title: Use Predictive Prefetching Selectively
+impact: MEDIUM
+tags: prefetch, selective, performance
+---
+
+## Use Predictive Prefetching Selectively
+
+Predictive prefetching doesn't belong in every project. Use it where navigation latency is noticeable.
+
+**Good use cases:** data-heavy dashboards, multi-page apps with slow API responses, e-commerce product pages.
+
+**Bad use cases:** static sites with instant navigation, single-page apps with all data preloaded.

--- a/.claude/skills/userinterface-wiki/rules/presence-disable-interactions.md
+++ b/.claude/skills/userinterface-wiki/rules/presence-disable-interactions.md
@@ -1,0 +1,31 @@
+---
+title: Disable Interactions on Exiting Elements
+impact: MEDIUM
+tags: presence, interaction, exit
+---
+
+## Disable Interactions on Exiting Elements
+
+Disable interactions on exiting elements using isPresent.
+
+**Incorrect (clickable during exit):**
+
+```tsx
+function Card() {
+  const isPresent = useIsPresent();
+  return <button onClick={handleClick}>Click</button>;
+}
+```
+
+**Correct (disabled during exit):**
+
+```tsx
+function Card() {
+  const isPresent = useIsPresent();
+  return (
+    <button onClick={handleClick} disabled={!isPresent}>
+      Click
+    </button>
+  );
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/presence-hook-in-child.md
+++ b/.claude/skills/userinterface-wiki/rules/presence-hook-in-child.md
@@ -1,0 +1,31 @@
+---
+title: useIsPresent in Child Component
+impact: HIGH
+tags: presence, hook, component-hierarchy
+---
+
+## useIsPresent in Child Component
+
+useIsPresent must be called from child of AnimatePresence, not parent.
+
+**Incorrect (hook in parent):**
+
+```tsx
+function Parent() {
+  const isPresent = useIsPresent();
+  return (
+    <AnimatePresence>
+      {show && <Child />}
+    </AnimatePresence>
+  );
+}
+```
+
+**Correct (hook in child):**
+
+```tsx
+function Child() {
+  const isPresent = useIsPresent();
+  return <motion.div data-exiting={!isPresent} />;
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/presence-safe-to-remove.md
+++ b/.claude/skills/userinterface-wiki/rules/presence-safe-to-remove.md
@@ -1,0 +1,37 @@
+---
+title: Call safeToRemove After Async Work
+impact: HIGH
+tags: presence, safe-to-remove, async
+---
+
+## Call safeToRemove After Async Work
+
+When using usePresence, always call safeToRemove after async work.
+
+**Incorrect (missing safeToRemove):**
+
+```tsx
+function AsyncComponent() {
+  const [isPresent, safeToRemove] = usePresence();
+
+  useEffect(() => {
+    if (!isPresent) {
+      cleanup();
+    }
+  }, [isPresent]);
+}
+```
+
+**Correct (safeToRemove called):**
+
+```tsx
+function AsyncComponent() {
+  const [isPresent, safeToRemove] = usePresence();
+
+  useEffect(() => {
+    if (!isPresent) {
+      cleanup().then(safeToRemove);
+    }
+  }, [isPresent, safeToRemove]);
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/pseudo-content-required.md
+++ b/.claude/skills/userinterface-wiki/rules/pseudo-content-required.md
@@ -1,0 +1,28 @@
+---
+title: Content Property Required for Pseudo-Elements
+impact: HIGH
+tags: pseudo, content, before-after
+---
+
+## Content Property Required for Pseudo-Elements
+
+::before and ::after require content property to render.
+
+**Incorrect (missing content):**
+
+```css
+.button::before {
+  position: absolute;
+  background: var(--gray-3);
+}
+```
+
+**Correct (content set):**
+
+```css
+.button::before {
+  content: "";
+  position: absolute;
+  background: var(--gray-3);
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/pseudo-first-line-styling.md
+++ b/.claude/skills/userinterface-wiki/rules/pseudo-first-line-styling.md
@@ -1,0 +1,27 @@
+---
+title: Use ::first-line for Typographic Treatments
+impact: LOW
+tags: pseudo, first-line, typography
+---
+
+## Use ::first-line for Typographic Treatments
+
+Use ::first-line for drop-cap-adjacent styling without JavaScript or hardcoded spans.
+
+**Incorrect (manual span):**
+
+```tsx
+<p>
+  <span className={styles["first-line"]}>The opening line of this paragraph</span>
+  is styled differently from the rest.
+</p>
+```
+
+**Correct (native ::first-line):**
+
+```css
+.article p:first-of-type::first-line {
+  font-variant-caps: small-caps;
+  font-weight: var(--font-weight-medium);
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/pseudo-hit-target-expansion.md
+++ b/.claude/skills/userinterface-wiki/rules/pseudo-hit-target-expansion.md
@@ -1,0 +1,31 @@
+---
+title: Hit Target Expansion with Pseudo-Elements
+impact: MEDIUM
+tags: pseudo, hit-target, accessibility
+---
+
+## Hit Target Expansion with Pseudo-Elements
+
+Use negative inset values to expand hit targets without extra markup.
+
+**Incorrect (wrapper for hit target):**
+
+```tsx
+<div className={styles.wrapper}>
+  <a className={styles.link}>Link</a>
+</div>
+```
+
+**Correct (pseudo-element expansion):**
+
+```css
+.link {
+  position: relative;
+}
+
+.link::before {
+  content: "";
+  position: absolute;
+  inset: -8px -12px;
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/pseudo-marker-styling.md
+++ b/.claude/skills/userinterface-wiki/rules/pseudo-marker-styling.md
@@ -1,0 +1,28 @@
+---
+title: Use ::marker for Custom List Bullets
+impact: LOW
+tags: pseudo, marker, list, bullets
+---
+
+## Use ::marker for Custom List Bullets
+
+Use ::marker to style list bullets without extra elements or background-image hacks.
+
+**Incorrect (background image hack):**
+
+```css
+li {
+  list-style: none;
+  background: url("bullet.svg") no-repeat 0 4px;
+  padding-left: 20px;
+}
+```
+
+**Correct (native ::marker):**
+
+```css
+li::marker {
+  color: var(--gray-8);
+  font-size: 0.8em;
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/pseudo-over-dom-node.md
+++ b/.claude/skills/userinterface-wiki/rules/pseudo-over-dom-node.md
@@ -1,0 +1,32 @@
+---
+title: Pseudo-Elements Over DOM Nodes
+impact: MEDIUM
+tags: pseudo, dom, decorative
+---
+
+## Pseudo-Elements Over DOM Nodes
+
+Use pseudo-elements for decorative content instead of extra DOM nodes.
+
+**Incorrect (extra DOM node):**
+
+```tsx
+<button className={styles.button}>
+  <span className={styles.background} />
+  Click me
+</button>
+```
+
+**Correct (pseudo-element):**
+
+```tsx
+<button className={styles.button}>
+  Click me
+</button>
+```
+```css
+.button::before {
+  content: "";
+  /* decorative background */
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/pseudo-position-relative-parent.md
+++ b/.claude/skills/userinterface-wiki/rules/pseudo-position-relative-parent.md
@@ -1,0 +1,33 @@
+---
+title: Position Relative Parent for Pseudo-Elements
+impact: HIGH
+tags: pseudo, position, relative
+---
+
+## Position Relative Parent for Pseudo-Elements
+
+Parent must have position: relative for absolute pseudo-elements.
+
+**Incorrect (no position on parent):**
+
+```css
+.button::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+}
+```
+
+**Correct (parent positioned):**
+
+```css
+.button {
+  position: relative;
+}
+
+.button::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/pseudo-z-index-layering.md
+++ b/.claude/skills/userinterface-wiki/rules/pseudo-z-index-layering.md
@@ -1,0 +1,37 @@
+---
+title: Z-Index Layering for Pseudo-Elements
+impact: MEDIUM
+tags: pseudo, z-index, layering
+---
+
+## Z-Index Layering for Pseudo-Elements
+
+Pseudo-elements need z-index to layer correctly with content.
+
+**Incorrect (covers text):**
+
+```css
+.button::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--gray-3);
+}
+```
+
+**Correct (layered behind):**
+
+```css
+.button {
+  position: relative;
+  z-index: 1;
+}
+
+.button::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--gray-3);
+  z-index: -1;
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/spring-for-gestures.md
+++ b/.claude/skills/userinterface-wiki/rules/spring-for-gestures.md
@@ -1,0 +1,27 @@
+---
+title: Springs for Gesture-Driven Motion
+impact: HIGH
+tags: spring, gesture, drag
+---
+
+## Springs for Gesture-Driven Motion
+
+Gesture-driven motion (drag, flick, swipe) must use springs.
+
+**Incorrect (easing for drag):**
+
+```tsx
+<motion.div
+  drag="x"
+  transition={{ duration: 0.3, ease: "easeOut" }}
+/>
+```
+
+**Correct (spring for drag):**
+
+```tsx
+<motion.div
+  drag="x"
+  transition={{ type: "spring", stiffness: 500, damping: 30 }}
+/>
+```

--- a/.claude/skills/userinterface-wiki/rules/spring-for-interruptible.md
+++ b/.claude/skills/userinterface-wiki/rules/spring-for-interruptible.md
@@ -1,0 +1,27 @@
+---
+title: Springs for Interruptible Motion
+impact: HIGH
+tags: spring, interruptible, animation
+---
+
+## Springs for Interruptible Motion
+
+Motion that can be interrupted must use springs.
+
+**Incorrect (easing for interruptible):**
+
+```tsx
+<motion.div
+  animate={{ x: isOpen ? 200 : 0 }}
+  transition={{ duration: 0.3 }}
+/>
+```
+
+**Correct (spring for interruptible):**
+
+```tsx
+<motion.div
+  animate={{ x: isOpen ? 200 : 0 }}
+  transition={{ type: "spring", stiffness: 400, damping: 25 }}
+/>
+```

--- a/.claude/skills/userinterface-wiki/rules/spring-params-balanced.md
+++ b/.claude/skills/userinterface-wiki/rules/spring-params-balanced.md
@@ -1,0 +1,29 @@
+---
+title: Balanced Spring Parameters
+impact: MEDIUM
+tags: spring, stiffness, damping
+---
+
+## Balanced Spring Parameters
+
+Spring parameters must be balanced; avoid excessive oscillation.
+
+**Incorrect (too bouncy):**
+
+```tsx
+transition={{
+  type: "spring",
+  stiffness: 1000,
+  damping: 5,
+}}
+```
+
+**Correct (balanced):**
+
+```tsx
+transition={{
+  type: "spring",
+  stiffness: 500,
+  damping: 30,
+}}
+```

--- a/.claude/skills/userinterface-wiki/rules/spring-preserves-velocity.md
+++ b/.claude/skills/userinterface-wiki/rules/spring-preserves-velocity.md
@@ -1,0 +1,28 @@
+---
+title: Springs Preserve Input Velocity
+impact: MEDIUM
+tags: spring, velocity, drag
+---
+
+## Springs Preserve Input Velocity
+
+When velocity matters, use springs to preserve input energy.
+
+**Incorrect (velocity ignored):**
+
+```tsx
+onDragEnd={(e, info) => {
+  animate(target, { x: 0 }, { duration: 0.3 });
+}}
+```
+
+**Correct (velocity preserved):**
+
+```tsx
+onDragEnd={(e, info) => {
+  animate(target, { x: 0 }, {
+    type: "spring",
+    velocity: info.velocity.x,
+  });
+}}
+```

--- a/.claude/skills/userinterface-wiki/rules/staging-dim-background.md
+++ b/.claude/skills/userinterface-wiki/rules/staging-dim-background.md
@@ -1,0 +1,22 @@
+---
+title: Dim Background for Focus
+impact: MEDIUM
+impactDescription: Transparent overlays fail to direct focus; dimmed backgrounds isolate the modal and reduce distraction.
+tags: staging, modal, overlay
+---
+
+## Dim Background for Focus
+
+Modal/dialog backgrounds should dim to direct focus.
+
+**Incorrect (transparent overlay):**
+
+```css
+.overlay { background: transparent; }
+```
+
+**Correct (dimmed overlay):**
+
+```css
+.overlay { background: var(--black-a6); }
+```

--- a/.claude/skills/userinterface-wiki/rules/staging-one-focal-point.md
+++ b/.claude/skills/userinterface-wiki/rules/staging-one-focal-point.md
@@ -1,0 +1,24 @@
+---
+title: Single Focal Point
+impact: MEDIUM
+impactDescription: Competing animations split attention and reduce clarity; one focal point guides the user effectively.
+tags: staging, focus, attention
+---
+
+## Single Focal Point
+
+Only one element should animate prominently at a time.
+
+**Incorrect (competing animations):**
+
+```tsx
+<motion.div animate={{ scale: 1.1 }} />
+<motion.div animate={{ scale: 1.1 }} />
+```
+
+**Correct (single focal point):**
+
+```tsx
+<motion.div animate={{ scale: 1.1 }} />
+<motion.div animate={{ scale: 1 }} />
+```

--- a/.claude/skills/userinterface-wiki/rules/staging-z-index-hierarchy.md
+++ b/.claude/skills/userinterface-wiki/rules/staging-z-index-hierarchy.md
@@ -1,0 +1,22 @@
+---
+title: Z-Index Layering for Animated Elements
+impact: MEDIUM
+impactDescription: Missing z-index causes tooltips and overlays to render behind other content, breaking the visual hierarchy.
+tags: staging, z-index, layering
+---
+
+## Z-Index Layering for Animated Elements
+
+Animated elements must respect z-index layering.
+
+**Incorrect (no z-index):**
+
+```css
+.tooltip { /* No z-index, may render behind other elements */ }
+```
+
+**Correct (explicit z-index):**
+
+```css
+.tooltip { z-index: 50; }
+```

--- a/.claude/skills/userinterface-wiki/rules/timing-consistent.md
+++ b/.claude/skills/userinterface-wiki/rules/timing-consistent.md
@@ -1,0 +1,24 @@
+---
+title: Consistent Timing for Similar Elements
+impact: CRITICAL
+impactDescription: Inconsistent timing across similar elements creates a disjointed, unpolished feel and undermines design system coherence.
+tags: timing, consistency, animation
+---
+
+## Consistent Timing for Similar Elements
+
+Similar elements must use identical timing values.
+
+**Incorrect (inconsistent timing):**
+
+```css
+.button-primary { transition: 200ms; }
+.button-secondary { transition: 150ms; }
+```
+
+**Correct (consistent timing):**
+
+```css
+.button-primary { transition: 200ms; }
+.button-secondary { transition: 200ms; }
+```

--- a/.claude/skills/userinterface-wiki/rules/timing-no-entrance-context-menu.md
+++ b/.claude/skills/userinterface-wiki/rules/timing-no-entrance-context-menu.md
@@ -1,0 +1,22 @@
+---
+title: No Entrance Animation on Context Menus
+impact: HIGH
+impactDescription: Entrance animations on context menus delay access to options and feel unnecessary for ephemeral UI.
+tags: timing, context-menu, entrance
+---
+
+## No Entrance Animation on Context Menus
+
+Context menus should not animate on entrance (exit only).
+
+**Incorrect (animates entrance):**
+
+```tsx
+<motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} />
+```
+
+**Correct (exit only):**
+
+```tsx
+<motion.div exit={{ opacity: 0 }} />
+```

--- a/.claude/skills/userinterface-wiki/rules/timing-under-300ms.md
+++ b/.claude/skills/userinterface-wiki/rules/timing-under-300ms.md
@@ -1,0 +1,22 @@
+---
+title: User Animations Under 300ms
+impact: CRITICAL
+impactDescription: Exceeding 300ms for user-initiated actions degrades perceived responsiveness and makes the interface feel sluggish.
+tags: timing, duration, animation
+---
+
+## User Animations Under 300ms
+
+User-initiated animations must complete within 300ms.
+
+**Incorrect (exceeds 300ms limit):**
+
+```css
+.button { transition: transform 400ms; }
+```
+
+**Correct (within 300ms):**
+
+```css
+.button { transition: transform 200ms; }
+```

--- a/.claude/skills/userinterface-wiki/rules/transition-name-cleanup.md
+++ b/.claude/skills/userinterface-wiki/rules/transition-name-cleanup.md
@@ -1,0 +1,28 @@
+---
+title: Clean Up View Transition Names
+impact: MEDIUM
+tags: view-transition, cleanup
+---
+
+## Clean Up View Transition Names
+
+Remove view-transition-name after transition completes.
+
+**Incorrect (stale name):**
+
+```ts
+sourceImg.style.viewTransitionName = "card";
+document.startViewTransition(() => {
+  targetImg.style.viewTransitionName = "card";
+});
+```
+
+**Correct (name cleaned up):**
+
+```ts
+sourceImg.style.viewTransitionName = "card";
+document.startViewTransition(() => {
+  sourceImg.style.viewTransitionName = "";
+  targetImg.style.viewTransitionName = "card";
+});
+```

--- a/.claude/skills/userinterface-wiki/rules/transition-name-required.md
+++ b/.claude/skills/userinterface-wiki/rules/transition-name-required.md
@@ -1,0 +1,27 @@
+---
+title: View Transition Name Required
+impact: HIGH
+tags: view-transition, transition-name
+---
+
+## View Transition Name Required
+
+Elements participating in view transitions need view-transition-name.
+
+**Incorrect (no transition name):**
+
+```ts
+document.startViewTransition(() => {
+  targetImg.src = newSrc;
+});
+```
+
+**Correct (transition name assigned):**
+
+```ts
+sourceImg.style.viewTransitionName = "card";
+document.startViewTransition(() => {
+  sourceImg.style.viewTransitionName = "";
+  targetImg.style.viewTransitionName = "card";
+});
+```

--- a/.claude/skills/userinterface-wiki/rules/transition-name-unique.md
+++ b/.claude/skills/userinterface-wiki/rules/transition-name-unique.md
@@ -1,0 +1,24 @@
+---
+title: Unique View Transition Names
+impact: HIGH
+tags: view-transition, unique, naming
+---
+
+## Unique View Transition Names
+
+Each view-transition-name must be unique on the page during transition.
+
+**Incorrect (duplicate names):**
+
+```css
+.card {
+  view-transition-name: card;
+}
+/* Multiple cards with same name */
+```
+
+**Correct (unique per element):**
+
+```ts
+element.style.viewTransitionName = `card-${id}`;
+```

--- a/.claude/skills/userinterface-wiki/rules/transition-over-js-library.md
+++ b/.claude/skills/userinterface-wiki/rules/transition-over-js-library.md
@@ -1,0 +1,32 @@
+---
+title: View Transitions Over JS Libraries
+impact: MEDIUM
+tags: view-transition, native, performance
+---
+
+## View Transitions Over JS Libraries
+
+Prefer View Transitions API over JavaScript animation libraries for page transitions.
+
+**Incorrect (JS-based transition):**
+
+```tsx
+import { motion } from "motion/react";
+
+function ImageLightbox() {
+  return (
+    <motion.img layoutId="hero" />
+  );
+}
+```
+
+**Correct (native View Transition):**
+
+```ts
+function openLightbox(img: HTMLImageElement) {
+  img.style.viewTransitionName = "hero";
+  document.startViewTransition(() => {
+    // Native browser transition
+  });
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/transition-style-pseudo-elements.md
+++ b/.claude/skills/userinterface-wiki/rules/transition-style-pseudo-elements.md
@@ -1,0 +1,24 @@
+---
+title: Style View Transition Pseudo-Elements
+impact: MEDIUM
+tags: view-transition, pseudo, styling
+---
+
+## Style View Transition Pseudo-Elements
+
+Style view transition pseudo-elements for custom animations.
+
+**Incorrect (default crossfade only):**
+
+```ts
+document.startViewTransition(() => { /* ... */ });
+```
+
+**Correct (custom animation):**
+
+```css
+::view-transition-group(card) {
+  animation-duration: 300ms;
+  animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/type-antialiased-on-retina.md
+++ b/.claude/skills/userinterface-wiki/rules/type-antialiased-on-retina.md
@@ -1,0 +1,18 @@
+---
+title: Use Antialiased Font Smoothing
+impact: MEDIUM
+tags: type, rendering, antialiased
+---
+
+## Use Antialiased Font Smoothing
+
+Set -webkit-font-smoothing: antialiased on retina displays. The default subpixel rendering looks thicker and fuzzier.
+
+**Correct:**
+
+```css
+body {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/type-disambiguation-stylistic-set.md
+++ b/.claude/skills/userinterface-wiki/rules/type-disambiguation-stylistic-set.md
@@ -1,0 +1,15 @@
+---
+title: Use Disambiguation Stylistic Set for UI
+impact: MEDIUM
+tags: type, stylistic-set, disambiguation
+---
+
+## Use Disambiguation Stylistic Set for UI
+
+Enable ss02 (or your font's disambiguation set) in code-facing UIs to distinguish I, l, 1 and 0, O.
+
+**Correct:**
+
+```css
+.code-ui { font-feature-settings: "ss02"; }
+```

--- a/.claude/skills/userinterface-wiki/rules/type-font-display-swap.md
+++ b/.claude/skills/userinterface-wiki/rules/type-font-display-swap.md
@@ -1,0 +1,28 @@
+---
+title: Use font-display swap to Avoid Invisible Text
+impact: MEDIUM
+tags: type, font-display, loading, FOIT
+---
+
+## Use font-display swap to Avoid Invisible Text
+
+Set font-display: swap so text renders immediately with a fallback font while the custom font loads.
+
+**Incorrect (invisible text during load):**
+
+```css
+@font-face {
+  font-family: "Inter";
+  src: url("/fonts/inter.woff2") format("woff2");
+}
+```
+
+**Correct (text visible immediately):**
+
+```css
+@font-face {
+  font-family: "Inter";
+  src: url("/fonts/inter.woff2") format("woff2");
+  font-display: swap;
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/type-justify-with-hyphens.md
+++ b/.claude/skills/userinterface-wiki/rules/type-justify-with-hyphens.md
@@ -1,0 +1,24 @@
+---
+title: Pair Justified Text with Hyphens
+impact: MEDIUM
+tags: type, justify, hyphens, rivers
+---
+
+## Pair Justified Text with Hyphens
+
+Justified text without hyphens creates rivers of whitespace. Always pair with hyphens: auto.
+
+**Incorrect (rivers of whitespace):**
+
+```css
+.article { text-align: justify; }
+```
+
+**Correct (hyphenation prevents rivers):**
+
+```css
+.article {
+  text-align: justify;
+  hyphens: auto;
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/type-letter-spacing-uppercase.md
+++ b/.claude/skills/userinterface-wiki/rules/type-letter-spacing-uppercase.md
@@ -1,0 +1,28 @@
+---
+title: Add Letter Spacing to Uppercase Text
+impact: MEDIUM
+tags: type, letter-spacing, uppercase, small-caps
+---
+
+## Add Letter Spacing to Uppercase Text
+
+Uppercase and small-caps text needs positive letter-spacing to feel open and readable.
+
+**Incorrect (tight uppercase):**
+
+```css
+.label {
+  text-transform: uppercase;
+  font-size: 12px;
+}
+```
+
+**Correct (opened up):**
+
+```css
+.label {
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.05em;
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/type-no-font-synthesis.md
+++ b/.claude/skills/userinterface-wiki/rules/type-no-font-synthesis.md
@@ -1,0 +1,18 @@
+---
+title: Disable Font Synthesis for Missing Styles
+impact: LOW
+tags: type, synthesis, italic, bold
+---
+
+## Disable Font Synthesis for Missing Styles
+
+Set font-synthesis: none to prevent the browser from faking bold or italic. Browser-generated faux styles look terrible.
+
+**Correct:**
+
+```css
+.icon-font,
+.display-font {
+  font-synthesis: none;
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/type-oldstyle-nums-for-prose.md
+++ b/.claude/skills/userinterface-wiki/rules/type-oldstyle-nums-for-prose.md
@@ -1,0 +1,21 @@
+---
+title: Oldstyle Numbers for Body Text
+impact: MEDIUM
+tags: type, numeric, oldstyle, prose
+---
+
+## Oldstyle Numbers for Body Text
+
+Use oldstyle-nums in body text so numbers blend with lowercase letters. Use lining-nums in tables and headings.
+
+**Correct (prose):**
+
+```css
+.body-text { font-variant-numeric: oldstyle-nums; }
+```
+
+**Correct (data):**
+
+```css
+.data-table { font-variant-numeric: lining-nums tabular-nums; }
+```

--- a/.claude/skills/userinterface-wiki/rules/type-opentype-contextual-alternates.md
+++ b/.claude/skills/userinterface-wiki/rules/type-opentype-contextual-alternates.md
@@ -1,0 +1,15 @@
+---
+title: Enable Contextual Alternates
+impact: MEDIUM
+tags: type, opentype, calt
+---
+
+## Enable Contextual Alternates
+
+Keep contextual alternates enabled (calt). They adjust punctuation and glyph shapes based on surrounding characters.
+
+**Correct (usually on by default, don't disable):**
+
+```css
+body { font-feature-settings: "calt" 1; }
+```

--- a/.claude/skills/userinterface-wiki/rules/type-optical-sizing-auto.md
+++ b/.claude/skills/userinterface-wiki/rules/type-optical-sizing-auto.md
@@ -1,0 +1,25 @@
+---
+title: Keep Optical Sizing Auto
+impact: MEDIUM
+tags: type, variable-font, optical-sizing
+---
+
+## Keep Optical Sizing Auto
+
+Leave font-optical-sizing at auto. The font adjusts glyph shapes for the current size — thicker strokes at small sizes, finer details at large sizes.
+
+**Incorrect (forced optical size):**
+
+```css
+body {
+  font-optical-sizing: none;
+}
+```
+
+**Correct (automatic adjustment):**
+
+```css
+body {
+  font-optical-sizing: auto;
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/type-proper-fractions.md
+++ b/.claude/skills/userinterface-wiki/rules/type-proper-fractions.md
@@ -1,0 +1,15 @@
+---
+title: Use Typographic Fractions
+impact: LOW
+tags: type, fractions, numeric, opentype
+---
+
+## Use Typographic Fractions
+
+Enable diagonal-fractions to convert 1/2, 1/3, etc. into proper typographic fractions.
+
+**Correct:**
+
+```css
+.recipe { font-variant-numeric: diagonal-fractions; }
+```

--- a/.claude/skills/userinterface-wiki/rules/type-slashed-zero.md
+++ b/.claude/skills/userinterface-wiki/rules/type-slashed-zero.md
@@ -1,0 +1,17 @@
+---
+title: Slashed Zero for Disambiguation
+impact: MEDIUM
+tags: type, zero, disambiguation
+---
+
+## Slashed Zero for Disambiguation
+
+Enable slashed zero in code-adjacent UIs so users never confuse 0 with O.
+
+**Correct:**
+
+```css
+.code { font-variant-numeric: slashed-zero; }
+/* or */
+.code { font-feature-settings: "zero"; }
+```

--- a/.claude/skills/userinterface-wiki/rules/type-tabular-nums-for-data.md
+++ b/.claude/skills/userinterface-wiki/rules/type-tabular-nums-for-data.md
@@ -1,0 +1,21 @@
+---
+title: Tabular Numbers for Data Display
+impact: HIGH
+tags: type, numeric, tabular, alignment
+---
+
+## Tabular Numbers for Data Display
+
+Use tabular-nums for any numeric data that should align in columns (tables, dashboards, pricing).
+
+**Incorrect (proportional numbers misalign):**
+
+```css
+.price { font-variant-numeric: proportional-nums; }
+```
+
+**Correct (tabular numbers align):**
+
+```css
+.price { font-variant-numeric: tabular-nums; }
+```

--- a/.claude/skills/userinterface-wiki/rules/type-text-wrap-balance-headings.md
+++ b/.claude/skills/userinterface-wiki/rules/type-text-wrap-balance-headings.md
@@ -1,0 +1,21 @@
+---
+title: Balance Headings with text-wrap
+impact: MEDIUM
+tags: type, text-wrap, balance, headings
+---
+
+## Balance Headings with text-wrap
+
+Use text-wrap: balance on headings to make lines roughly equal length instead of one long line and a short orphan.
+
+**Incorrect (unbalanced heading):**
+
+```css
+h1 { /* default text-wrap */ }
+```
+
+**Correct (balanced):**
+
+```css
+h1 { text-wrap: balance; }
+```

--- a/.claude/skills/userinterface-wiki/rules/type-text-wrap-pretty.md
+++ b/.claude/skills/userinterface-wiki/rules/type-text-wrap-pretty.md
@@ -1,0 +1,16 @@
+---
+title: Use text-wrap pretty for Body Text
+impact: MEDIUM
+tags: type, text-wrap, orphans, pretty
+---
+
+## Use text-wrap pretty for Body Text
+
+Use text-wrap: pretty for body text to reduce orphans. Use text-wrap: balance for headings.
+
+**Correct:**
+
+```css
+p { text-wrap: pretty; }
+h1, h2, h3 { text-wrap: balance; }
+```

--- a/.claude/skills/userinterface-wiki/rules/type-underline-offset.md
+++ b/.claude/skills/userinterface-wiki/rules/type-underline-offset.md
@@ -1,0 +1,25 @@
+---
+title: Offset Underlines from Descenders
+impact: MEDIUM
+tags: type, underline, offset, decoration
+---
+
+## Offset Underlines from Descenders
+
+Use text-underline-offset to push underlines below descenders so they look intentional.
+
+**Incorrect (underline collides with descenders):**
+
+```css
+a { text-decoration: underline; }
+```
+
+**Correct (offset underline):**
+
+```css
+a {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-skip-ink: auto;
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/type-variable-weight-continuous.md
+++ b/.claude/skills/userinterface-wiki/rules/type-variable-weight-continuous.md
@@ -1,0 +1,23 @@
+---
+title: Use Continuous Weight Values with Variable Fonts
+impact: LOW
+tags: type, variable-font, weight
+---
+
+## Use Continuous Weight Values with Variable Fonts
+
+Variable fonts accept any integer from 100-900, not just the standard stops at 400, 500, 600, 700.
+
+**Incorrect (limited to standard stops):**
+
+```css
+.medium { font-weight: 500; }
+.semibold { font-weight: 600; }
+```
+
+**Correct (precise weight control):**
+
+```css
+.medium { font-weight: 450; }
+.semibold { font-weight: 550; }
+```

--- a/.claude/skills/userinterface-wiki/rules/ux-aesthetic-usability.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-aesthetic-usability.md
@@ -1,0 +1,32 @@
+---
+title: Visual Polish Increases Perceived Usability
+impact: MEDIUM
+tags: ux, aesthetic, usability, polish
+---
+
+## Visual Polish Increases Perceived Usability
+
+Users perceive aesthetically pleasing design as more usable. Small visual details compound into trust.
+
+**Incorrect (unstyled, raw elements):**
+
+```css
+.card {
+  border: 1px solid black;
+  padding: 10px;
+}
+```
+
+**Correct (considered visual treatment):**
+
+```css
+.card {
+  padding: 16px;
+  background: var(--gray-2);
+  border: 1px solid var(--gray-a4);
+  border-radius: 12px;
+  box-shadow: var(--shadow-1);
+}
+```
+
+Reference: [Aesthetic-Usability Effect](https://lawsofux.com/aesthetic-usability-effect/)

--- a/.claude/skills/userinterface-wiki/rules/ux-cognitive-load-reduce.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-cognitive-load-reduce.md
@@ -1,0 +1,49 @@
+---
+title: Minimize Extraneous Cognitive Load
+impact: HIGH
+tags: ux, cognitive-load, simplicity, noise
+---
+
+## Minimize Extraneous Cognitive Load
+
+Remove anything that doesn't help the user complete their task. Decoration, redundant labels, and unnecessary options all add load.
+
+**Incorrect (extraneous elements):**
+
+```tsx
+function DeleteDialog() {
+  return (
+    <dialog>
+      <Icon name="warning" size={64} />
+      <h2>Warning!</h2>
+      <p>Are you absolutely sure you want to delete?</p>
+      <p>This action is permanent and cannot be undone.</p>
+      <p>All associated data will be lost forever.</p>
+      <div>
+        <button>Cancel</button>
+        <button>Delete</button>
+        <button>Learn More</button>
+      </div>
+    </dialog>
+  );
+}
+```
+
+**Correct (essential information only):**
+
+```tsx
+function DeleteDialog() {
+  return (
+    <dialog>
+      <h2>Delete this item?</h2>
+      <p>This can't be undone.</p>
+      <div>
+        <button>Cancel</button>
+        <button>Delete</button>
+      </div>
+    </dialog>
+  );
+}
+```
+
+Reference: [Cognitive Load](https://lawsofux.com/cognitive-load/)

--- a/.claude/skills/userinterface-wiki/rules/ux-common-region-boundaries.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-common-region-boundaries.md
@@ -1,0 +1,50 @@
+---
+title: Use Boundaries to Group Related Content
+impact: MEDIUM
+tags: ux, common-region, boundaries, grouping
+---
+
+## Use Boundaries to Group Related Content
+
+Elements sharing a clearly defined boundary are perceived as a group.
+
+**Incorrect (flat list with no visual grouping):**
+
+```tsx
+function Settings() {
+  return (
+    <div>
+      <Toggle label="Dark mode" />
+      <Toggle label="Notifications" />
+      <Input label="Email" />
+      <Input label="Password" />
+    </div>
+  );
+}
+```
+
+**Correct (bounded sections):**
+
+```tsx
+function Settings() {
+  return (
+    <div>
+      <section className={styles.group}>
+        <h3>Appearance</h3>
+        <Toggle label="Dark mode" />
+      </section>
+      <section className={styles.group}>
+        <h3>Notifications</h3>
+        <Toggle label="Notifications" />
+      </section>
+      <section className={styles.group}>
+        <h3>Account</h3>
+        <Input label="Email" />
+        <Input label="Password" />
+      </section>
+    </div>
+  );
+}
+```
+
+Reference: [Law of Common Region](https://lawsofux.com/law-of-common-region/)

--- a/.claude/skills/userinterface-wiki/rules/ux-doherty-perceived-speed.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-doherty-perceived-speed.md
@@ -1,0 +1,29 @@
+---
+title: Fake Speed When Actual Speed Isn't Possible
+impact: HIGH
+tags: ux, doherty, perceived-speed, skeleton
+---
+
+## Fake Speed When Actual Speed Isn't Possible
+
+If you can't make something fast, make it feel fast with optimistic UI, skeletons, or progress indicators.
+
+**Incorrect (blank screen during load):**
+
+```tsx
+function Page() {
+  const { data, isLoading } = useFetch("/api/data");
+  if (isLoading) return null;
+  return <Content data={data} />;
+}
+```
+
+**Correct (skeleton during load):**
+
+```tsx
+function Page() {
+  const { data, isLoading } = useFetch("/api/data");
+  if (isLoading) return <Skeleton />;
+  return <Content data={data} />;
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/ux-doherty-under-400ms.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-doherty-under-400ms.md
@@ -1,0 +1,30 @@
+---
+title: Respond Within 400ms
+impact: CRITICAL
+tags: ux, doherty, latency, response-time
+---
+
+## Respond Within 400ms
+
+Interactions must respond within 400ms to feel instant. Above this threshold, users notice delay.
+
+**Incorrect (no feedback during loading):**
+
+```tsx
+async function handleClick() {
+  const data = await fetchData();
+  setResult(data);
+}
+```
+
+**Correct (immediate optimistic feedback):**
+
+```tsx
+async function handleClick() {
+  setResult(optimisticData);
+  const data = await fetchData();
+  setResult(data);
+}
+```
+
+Reference: Doherty, W. J. (1979). Managing VM/CMS systems for user effectiveness.

--- a/.claude/skills/userinterface-wiki/rules/ux-fitts-hit-area.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-fitts-hit-area.md
@@ -1,0 +1,32 @@
+---
+title: Expand Hit Areas with Invisible Padding
+impact: HIGH
+tags: ux, fitts, hit-area, pseudo
+---
+
+## Expand Hit Areas with Invisible Padding
+
+Use pseudo-elements or invisible padding to expand clickable areas beyond visible bounds.
+
+**Incorrect (visible size equals hit area):**
+
+```css
+.link {
+  font-size: 14px;
+  /* Hit area matches text only */
+}
+```
+
+**Correct (expanded invisible hit area):**
+
+```css
+.link {
+  position: relative;
+}
+
+.link::before {
+  content: "";
+  position: absolute;
+  inset: -8px -12px;
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/ux-fitts-target-size.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-fitts-target-size.md
@@ -1,0 +1,31 @@
+---
+title: Size Interactive Targets for Easy Clicking
+impact: HIGH
+tags: ux, fitts, target-size
+---
+
+## Size Interactive Targets for Easy Clicking
+
+The bigger something is, the easier it is to click. Make interactive elements large enough to hit comfortably.
+
+**Incorrect (tiny click target):**
+
+```css
+.icon-button {
+  width: 16px;
+  height: 16px;
+  padding: 0;
+}
+```
+
+**Correct (comfortable target):**
+
+```css
+.icon-button {
+  width: 32px;
+  height: 32px;
+  padding: 8px;
+}
+```
+
+Reference: Fitts, P. M. (1954). The information capacity of the human motor system.

--- a/.claude/skills/userinterface-wiki/rules/ux-goal-gradient-progress.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-goal-gradient-progress.md
@@ -1,0 +1,33 @@
+---
+title: Show Progress Toward Completion
+impact: HIGH
+tags: ux, goal-gradient, progress, motivation
+---
+
+## Show Progress Toward Completion
+
+People accelerate behavior as they approach a goal. Show how close they are to finishing.
+
+**Incorrect (no sense of progress):**
+
+```tsx
+function Onboarding({ step }) {
+  return <OnboardingStep step={step} />;
+}
+```
+
+**Correct (progress visible):**
+
+```tsx
+function Onboarding({ step, totalSteps }) {
+  return (
+    <div>
+      <ProgressBar value={step} max={totalSteps} />
+      <span>Step {step} of {totalSteps}</span>
+      <OnboardingStep step={step} />
+    </div>
+  );
+}
+```
+
+Reference: [Goal-Gradient Effect](https://lawsofux.com/goal-gradient-effect/)

--- a/.claude/skills/userinterface-wiki/rules/ux-hicks-minimize-choices.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-hicks-minimize-choices.md
@@ -1,0 +1,45 @@
+---
+title: Minimize Choices to Reduce Decision Time
+impact: HIGH
+tags: ux, hicks, choices, cognitive-load
+---
+
+## Minimize Choices to Reduce Decision Time
+
+Decision time increases logarithmically with the number of choices. Use progressive disclosure.
+
+**Incorrect (all options at once):**
+
+```tsx
+function Settings() {
+  return (
+    <div>
+      {allSettings.map(setting => (
+        <SettingRow key={setting.id} {...setting} />
+      ))}
+    </div>
+  );
+}
+```
+
+**Correct (progressive disclosure):**
+
+```tsx
+function Settings() {
+  return (
+    <div>
+      {commonSettings.map(setting => (
+        <SettingRow key={setting.id} {...setting} />
+      ))}
+      <details>
+        <summary>Advanced</summary>
+        {advancedSettings.map(setting => (
+          <SettingRow key={setting.id} {...setting} />
+        ))}
+      </details>
+    </div>
+  );
+}
+```
+
+Reference: Hick, W. E. (1952). On the rate of gain of information.

--- a/.claude/skills/userinterface-wiki/rules/ux-jakobs-familiar-patterns.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-jakobs-familiar-patterns.md
@@ -1,0 +1,37 @@
+---
+title: Use Familiar UI Patterns
+impact: HIGH
+tags: ux, jakobs, familiarity, patterns
+---
+
+## Use Familiar UI Patterns
+
+Users spend most of their time on other sites. They expect yours to work the same way (Jakob's Law).
+
+**Incorrect (custom unconventional navigation):**
+
+```tsx
+function Nav() {
+  return (
+    <nav>
+      <button onClick={() => navigate("/")}>⬡</button>
+      <button onClick={() => navigate("/search")}>⬢</button>
+    </nav>
+  );
+}
+```
+
+**Correct (standard recognizable patterns):**
+
+```tsx
+function Nav() {
+  return (
+    <nav>
+      <Link href="/">Home</Link>
+      <Link href="/search">Search</Link>
+    </nav>
+  );
+}
+```
+
+Reference: [Jakob's Law](https://lawsofux.com/jakobs-law/)

--- a/.claude/skills/userinterface-wiki/rules/ux-millers-chunking.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-millers-chunking.md
@@ -1,0 +1,23 @@
+---
+title: Chunk Data into Groups of 5-9
+impact: HIGH
+tags: ux, millers, chunking, memory
+---
+
+## Chunk Data into Groups of 5-9
+
+Working memory holds about 7 items. Group and chunk large data sets so they're scannable.
+
+**Incorrect (raw unformatted data):**
+
+```tsx
+<span>4532015112830366</span>
+```
+
+**Correct (chunked for readability):**
+
+```tsx
+<span>4532 0151 1283 0366</span>
+```
+
+Reference: Miller, G. A. (1956). The magical number seven, plus or minus two.

--- a/.claude/skills/userinterface-wiki/rules/ux-pareto-prioritize-features.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-pareto-prioritize-features.md
@@ -1,0 +1,36 @@
+---
+title: Prioritize the Critical 20% of Features
+impact: MEDIUM
+tags: ux, pareto, prioritization, features
+---
+
+## Prioritize the Critical 20% of Features
+
+80% of users use 20% of features (Pareto Principle). Optimize the critical path first.
+
+**Incorrect (all features equally prominent):**
+
+```tsx
+function Toolbar() {
+  return (
+    <div>
+      {allFeatures.map(f => <Button key={f.id}>{f.label}</Button>)}
+    </div>
+  );
+}
+```
+
+**Correct (critical features prominent, rest accessible):**
+
+```tsx
+function Toolbar() {
+  return (
+    <div>
+      {criticalFeatures.map(f => <Button key={f.id}>{f.label}</Button>)}
+      <MoreMenu features={secondaryFeatures} />
+    </div>
+  );
+}
+```
+
+Reference: [Pareto Principle](https://lawsofux.com/pareto-principle/)

--- a/.claude/skills/userinterface-wiki/rules/ux-peak-end-finish-strong.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-peak-end-finish-strong.md
@@ -1,0 +1,35 @@
+---
+title: End Experiences with Clear Success States
+impact: MEDIUM
+tags: ux, peak-end, success, completion
+---
+
+## End Experiences with Clear Success States
+
+People judge experiences by their peak moment and their end. Invest in success and completion states.
+
+**Incorrect (abrupt end after action):**
+
+```tsx
+async function handleSubmit() {
+  await submitForm(data);
+  router.push("/");
+}
+```
+
+**Correct (satisfying completion state):**
+
+```tsx
+async function handleSubmit() {
+  await submitForm(data);
+  setStatus("success");
+}
+
+return status === "success" ? (
+  <SuccessScreen message="You're all set." />
+) : (
+  <Form onSubmit={handleSubmit} />
+);
+```
+
+Reference: [Peak-End Rule](https://lawsofux.com/peak-end-rule/)

--- a/.claude/skills/userinterface-wiki/rules/ux-postels-accept-messy-input.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-postels-accept-messy-input.md
@@ -1,0 +1,45 @@
+---
+title: Accept Messy Input, Output Clean Data
+impact: MEDIUM
+tags: ux, postels, input, validation
+---
+
+## Accept Messy Input, Output Clean Data
+
+Inputs should accept messy human data and normalize it. Validate generously, format strictly.
+
+**Incorrect (rigid format required):**
+
+```tsx
+function DateInput({ onChange }) {
+  return (
+    <input
+      type="text"
+      placeholder="YYYY-MM-DD"
+      pattern="\d{4}-\d{2}-\d{2}"
+      onChange={onChange}
+    />
+  );
+}
+```
+
+**Correct (accepts multiple formats):**
+
+```tsx
+function DateInput({ onChange }) {
+  function handleChange(e) {
+    const parsed = parseFlexibleDate(e.target.value);
+    if (parsed) onChange(parsed);
+  }
+
+  return (
+    <input
+      type="text"
+      placeholder="Any date format"
+      onChange={handleChange}
+    />
+  );
+}
+```
+
+Reference: Postel, J. (1980). RFC 761 — Transmission Control Protocol.

--- a/.claude/skills/userinterface-wiki/rules/ux-pragnanz-simplify.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-pragnanz-simplify.md
@@ -1,0 +1,33 @@
+---
+title: Simplify Complex Visuals into Clear Forms
+impact: MEDIUM
+tags: ux, pragnanz, simplicity, clarity
+---
+
+## Simplify Complex Visuals into Clear Forms
+
+People interpret complex visuals as the simplest form possible. Reduce visual noise to aid comprehension.
+
+**Incorrect (visually noisy layout):**
+
+```css
+.card {
+  border: 2px dashed red;
+  background: linear-gradient(45deg, #f0f, #0ff);
+  box-shadow: 5px 5px 0 black, 10px 10px 0 gray;
+  outline: 3px dotted blue;
+}
+```
+
+**Correct (clear, simple form):**
+
+```css
+.card {
+  background: var(--gray-2);
+  border: 1px solid var(--gray-a4);
+  border-radius: 12px;
+  box-shadow: var(--shadow-1);
+}
+```
+
+Reference: [Law of Prägnanz](https://lawsofux.com/law-of-pragnanz/)

--- a/.claude/skills/userinterface-wiki/rules/ux-progressive-disclosure.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-progressive-disclosure.md
@@ -1,0 +1,41 @@
+---
+title: Show What Matters Now, Reveal Complexity Later
+impact: HIGH
+tags: ux, progressive-disclosure, complexity
+---
+
+## Show What Matters Now, Reveal Complexity Later
+
+Don't overwhelm users with everything at once. Reveal complexity incrementally as needed.
+
+**Incorrect (all controls visible):**
+
+```tsx
+function Editor() {
+  return (
+    <div>
+      <BasicTools />
+      <AdvancedTools />
+      <ExpertTools />
+      <DebugTools />
+    </div>
+  );
+}
+```
+
+**Correct (progressive disclosure):**
+
+```tsx
+function Editor() {
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  return (
+    <div>
+      <BasicTools />
+      {showAdvanced && <AdvancedTools />}
+      <button onClick={() => setShowAdvanced(!showAdvanced)}>
+        Toggle
+      </button>
+    </div>
+  );
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/ux-proximity-grouping.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-proximity-grouping.md
@@ -1,0 +1,38 @@
+---
+title: Group Related Elements Spatially
+impact: HIGH
+tags: ux, proximity, grouping, layout
+---
+
+## Group Related Elements Spatially
+
+Elements near each other are perceived as related. Use spacing to create visual groups.
+
+**Incorrect (uniform spacing between unrelated items):**
+
+```css
+.form label,
+.form input,
+.form .hint,
+.form .divider {
+  margin-bottom: 16px;
+}
+```
+
+**Correct (tighter spacing within groups, larger between):**
+
+```css
+.form label {
+  margin-bottom: 4px;
+}
+
+.form input {
+  margin-bottom: 2px;
+}
+
+.form .hint {
+  margin-bottom: 24px;
+}
+```
+
+Reference: [Law of Proximity](https://lawsofux.com/law-of-proximity/)

--- a/.claude/skills/userinterface-wiki/rules/ux-serial-position.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-serial-position.md
@@ -1,0 +1,31 @@
+---
+title: Place Key Items First or Last
+impact: MEDIUM
+tags: ux, serial-position, navigation, order
+---
+
+## Place Key Items First or Last
+
+Users best remember the first and last items in a sequence. Place the most important actions at these positions.
+
+**Incorrect (important action buried in middle):**
+
+```tsx
+<nav>
+  <Link href="/settings">Settings</Link>
+  <Link href="/">Home</Link>
+  <Link href="/about">About</Link>
+</nav>
+```
+
+**Correct (key items at edges):**
+
+```tsx
+<nav>
+  <Link href="/">Home</Link>
+  <Link href="/about">About</Link>
+  <Link href="/settings">Settings</Link>
+</nav>
+```
+
+Reference: [Serial Position Effect](https://lawsofux.com/serial-position-effect/)

--- a/.claude/skills/userinterface-wiki/rules/ux-similarity-consistency.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-similarity-consistency.md
@@ -1,0 +1,35 @@
+---
+title: Similar Elements Should Look Alike
+impact: HIGH
+tags: ux, similarity, consistency, visual
+---
+
+## Similar Elements Should Look Alike
+
+Elements that function the same should look the same. Visual consistency signals functional consistency.
+
+**Incorrect (same function, different appearance):**
+
+```css
+.save-button {
+  background: blue;
+  border-radius: 8px;
+}
+
+.submit-button {
+  background: green;
+  border-radius: 0;
+}
+```
+
+**Correct (same function, same appearance):**
+
+```css
+.primary-action {
+  background: var(--gray-12);
+  color: var(--gray-1);
+  border-radius: 8px;
+}
+```
+
+Reference: [Law of Similarity](https://lawsofux.com/law-of-similarity/)

--- a/.claude/skills/userinterface-wiki/rules/ux-teslers-complexity.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-teslers-complexity.md
@@ -1,0 +1,28 @@
+---
+title: Move Complexity, Don't Hide It
+impact: MEDIUM
+tags: ux, teslers, complexity, simplicity
+---
+
+## Move Complexity, Don't Hide It
+
+Every system has irreducible complexity. The question is who handles it — the user or the system.
+
+**Incorrect (complexity pushed to user):**
+
+```tsx
+<input
+  type="text"
+  placeholder="Enter date as YYYY-MM-DDTHH:mm:ss.sssZ"
+/>
+```
+
+**Correct (system absorbs complexity):**
+
+```tsx
+<DatePicker
+  onChange={(date) => setDate(date.toISOString())}
+/>
+```
+
+Reference: [Tesler's Law](https://lawsofux.com/teslers-law/)

--- a/.claude/skills/userinterface-wiki/rules/ux-uniform-connectedness.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-uniform-connectedness.md
@@ -1,0 +1,43 @@
+---
+title: Visually Connect Related Elements
+impact: MEDIUM
+tags: ux, connectedness, grouping, visual
+---
+
+## Visually Connect Related Elements
+
+Elements that are visually connected (by lines, color, or frames) are perceived as more related.
+
+**Incorrect (steps with no visual connection):**
+
+```tsx
+function Steps({ current }) {
+  return (
+    <div>
+      <span>Step 1</span>
+      <span>Step 2</span>
+      <span>Step 3</span>
+    </div>
+  );
+}
+```
+
+**Correct (connected with a visual line):**
+
+```tsx
+function Steps({ current }) {
+  return (
+    <div className={styles.steps}>
+      {steps.map((step, i) => (
+        <div key={step.id} className={styles.step} data-active={i <= current}>
+          <div className={styles.dot} />
+          {i < steps.length - 1 && <div className={styles.connector} />}
+          <span>{step.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+Reference: [Law of Uniform Connectedness](https://lawsofux.com/law-of-uniform-connectedness/)

--- a/.claude/skills/userinterface-wiki/rules/ux-von-restorff-emphasis.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-von-restorff-emphasis.md
@@ -1,0 +1,29 @@
+---
+title: Make Important Elements Visually Distinct
+impact: HIGH
+tags: ux, von-restorff, emphasis, distinction
+---
+
+## Make Important Elements Visually Distinct
+
+When multiple similar elements are present, the one that differs is most likely to be remembered.
+
+**Incorrect (primary action blends in):**
+
+```tsx
+<div className={styles.actions}>
+  <button className={styles.button}>Cancel</button>
+  <button className={styles.button}>Delete Account</button>
+</div>
+```
+
+**Correct (destructive action stands out):**
+
+```tsx
+<div className={styles.actions}>
+  <button className={styles["button-secondary"]}>Cancel</button>
+  <button className={styles["button-danger"]}>Delete Account</button>
+</div>
+```
+
+Reference: [Von Restorff Effect](https://lawsofux.com/von-restorff-effect/)

--- a/.claude/skills/userinterface-wiki/rules/ux-zeigarnik-show-incomplete.md
+++ b/.claude/skills/userinterface-wiki/rules/ux-zeigarnik-show-incomplete.md
@@ -1,0 +1,36 @@
+---
+title: Show Incomplete State to Drive Completion
+impact: MEDIUM
+tags: ux, zeigarnik, incomplete, engagement
+---
+
+## Show Incomplete State to Drive Completion
+
+People remember incomplete tasks better than completed ones. Use this to drive engagement.
+
+**Incorrect (no indication of incomplete profile):**
+
+```tsx
+function Dashboard() {
+  return <DashboardContent />;
+}
+```
+
+**Correct (incomplete state visible):**
+
+```tsx
+function Dashboard({ profile }) {
+  return (
+    <div>
+      {!profile.isComplete && (
+        <Banner>
+          Complete your profile — {profile.completionPercent}% done
+        </Banner>
+      )}
+      <DashboardContent />
+    </div>
+  );
+}
+```
+
+Reference: [Zeigarnik Effect](https://lawsofux.com/zeigarnik-effect/)

--- a/.claude/skills/userinterface-wiki/rules/visual-animate-shadow-pseudo.md
+++ b/.claude/skills/userinterface-wiki/rules/visual-animate-shadow-pseudo.md
@@ -1,0 +1,49 @@
+---
+title: Animate Shadows via Pseudo-Element Opacity
+impact: MEDIUM
+tags: visual, shadow, animation, performance
+---
+
+## Animate Shadows via Pseudo-Element Opacity
+
+Transitioning box-shadow directly forces expensive repaints. Instead, put the target shadow on a pseudo-element and animate its opacity.
+
+**Incorrect (animating box-shadow):**
+
+```css
+.card {
+  box-shadow: var(--shadow-1);
+  transition: box-shadow 0.2s ease;
+}
+
+.card:hover {
+  box-shadow: var(--shadow-3);
+}
+```
+
+**Correct (pseudo-element opacity):**
+
+```css
+.card {
+  position: relative;
+  box-shadow: var(--shadow-1);
+}
+
+.card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: var(--shadow-3);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.card:hover::after {
+  opacity: 1;
+}
+```
+
+Reference: [Designing Beautiful Shadows in CSS](https://www.joshwcomeau.com/css/designing-shadows/)

--- a/.claude/skills/userinterface-wiki/rules/visual-border-alpha-colors.md
+++ b/.claude/skills/userinterface-wiki/rules/visual-border-alpha-colors.md
@@ -1,0 +1,25 @@
+---
+title: Use Semi-Transparent Borders for Subtle Separation
+impact: MEDIUM
+tags: visual, border, alpha, separation
+---
+
+## Use Semi-Transparent Borders for Subtle Separation
+
+Semi-transparent borders adapt to any background color and create subtle, non-jarring separation.
+
+**Incorrect (hardcoded border color):**
+
+```css
+.card {
+  border: 1px solid #e5e5e5;
+}
+```
+
+**Correct (alpha border):**
+
+```css
+.card {
+  border: 1px solid var(--gray-a4);
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/visual-button-shadow-anatomy.md
+++ b/.claude/skills/userinterface-wiki/rules/visual-button-shadow-anatomy.md
@@ -1,0 +1,49 @@
+---
+title: Use Full Shadow Anatomy on Buttons
+impact: HIGH
+tags: visual, shadow, button, depth, gradient
+---
+
+## Use Full Shadow Anatomy on Buttons
+
+A polished button uses six layered techniques, not just a single box-shadow.
+
+1. **Outer cut shadow** — 0.5px dark box-shadow to "cut" the button into the surface
+2. **Inner ambient highlight** — 1px inset box-shadow on all sides for environmental light reflections
+3. **Inner top highlight** — 1px inset top highlight for the primary light source from above
+4. **Layered depth shadows** — At least 3 external shadows for natural lighting
+5. **Text drop-shadow** — Drop-shadow on text/icons for better contrast against the button background
+6. **Subtle gradient background** — If you can tell there's a gradient, it's too much
+
+**Incorrect (flat button):**
+
+```css
+.button {
+  background: var(--gray-12);
+  color: var(--gray-1);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+```
+
+**Correct (full shadow anatomy):**
+
+```css
+.button {
+  background: linear-gradient(
+    to bottom,
+    color-mix(in srgb, var(--gray-12) 100%, white 4%),
+    var(--gray-12)
+  );
+  color: var(--gray-1);
+  box-shadow:
+    0 0 0 0.5px rgba(0, 0, 0, 0.3),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.04),
+    inset 0 1px 0 rgba(255, 255, 255, 0.07),
+    0 1px 2px rgba(0, 0, 0, 0.1),
+    0 2px 4px rgba(0, 0, 0, 0.06),
+    0 4px 8px rgba(0, 0, 0, 0.03);
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15);
+}
+```
+
+Reference: [@PixelJanitor](https://threadreaderapp.com/thread/1623358514440859649)

--- a/.claude/skills/userinterface-wiki/rules/visual-concentric-radius.md
+++ b/.claude/skills/userinterface-wiki/rules/visual-concentric-radius.md
@@ -1,0 +1,40 @@
+---
+title: Concentric Border Radius for Nested Elements
+impact: HIGH
+tags: visual, border-radius, concentric, nesting
+---
+
+## Concentric Border Radius for Nested Elements
+
+When nesting rounded elements, inner radius must equal outer radius minus the gap. Same radius on both creates uneven curves.
+
+**Incorrect (same radius on both):**
+
+```css
+.outer {
+  border-radius: 16px;
+  padding: 8px;
+}
+
+.inner {
+  border-radius: 16px;
+}
+```
+
+**Correct (concentric radius):**
+
+```css
+.outer {
+  --padding: 8px;
+  --inner-radius: 8px;
+
+  border-radius: calc(var(--inner-radius) + var(--padding));
+  padding: var(--padding);
+}
+
+.inner {
+  border-radius: var(--inner-radius);
+}
+```
+
+Reference: [Concentric Border Radius](https://jakub.kr/work/concentric-border-radius)

--- a/.claude/skills/userinterface-wiki/rules/visual-consistent-spacing-scale.md
+++ b/.claude/skills/userinterface-wiki/rules/visual-consistent-spacing-scale.md
@@ -1,0 +1,35 @@
+---
+title: Use a Consistent Spacing Scale
+impact: HIGH
+tags: visual, spacing, scale, consistency
+---
+
+## Use a Consistent Spacing Scale
+
+Don't use arbitrary pixel values for spacing. Define a scale and stick to it throughout the UI.
+
+**Incorrect (arbitrary values):**
+
+```css
+.header { padding: 17px; }
+.card { margin-bottom: 13px; }
+.section { gap: 22px; }
+```
+
+**Correct (consistent scale):**
+
+```css
+:root {
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+}
+
+.header { padding: var(--space-4); }
+.card { margin-bottom: var(--space-3); }
+.section { gap: var(--space-5); }
+```

--- a/.claude/skills/userinterface-wiki/rules/visual-layered-shadows.md
+++ b/.claude/skills/userinterface-wiki/rules/visual-layered-shadows.md
@@ -1,0 +1,30 @@
+---
+title: Layer Multiple Shadows for Realistic Depth
+impact: HIGH
+tags: visual, shadow, layered, depth
+---
+
+## Layer Multiple Shadows for Realistic Depth
+
+A single box-shadow looks flat. Layer multiple shadows with increasing blur and decreasing opacity to mimic real light.
+
+**Incorrect (single flat shadow):**
+
+```css
+.card {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+```
+
+**Correct (layered shadows):**
+
+```css
+.card {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.06),
+    0 4px 8px rgba(0, 0, 0, 0.04),
+    0 12px 24px rgba(0, 0, 0, 0.03);
+}
+```
+
+Reference: [Designing Beautiful Shadows in CSS](https://www.joshwcomeau.com/css/designing-shadows/)

--- a/.claude/skills/userinterface-wiki/rules/visual-no-pure-black-shadow.md
+++ b/.claude/skills/userinterface-wiki/rules/visual-no-pure-black-shadow.md
@@ -1,0 +1,25 @@
+---
+title: Use Neutral Colors for Shadows, Not Pure Black
+impact: MEDIUM
+tags: visual, shadow, color, neutral
+---
+
+## Use Neutral Colors for Shadows, Not Pure Black
+
+Pure black shadows look harsh and artificial. Use deep neutrals or semi-transparent dark colors.
+
+**Incorrect (pure black):**
+
+```css
+.card {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+}
+```
+
+**Correct (neutral shadow):**
+
+```css
+.card {
+  box-shadow: 0 4px 12px rgba(17, 24, 39, 0.08);
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/visual-shadow-direction.md
+++ b/.claude/skills/userinterface-wiki/rules/visual-shadow-direction.md
@@ -1,0 +1,25 @@
+---
+title: Consistent Shadow Direction Across UI
+impact: HIGH
+tags: visual, shadow, direction, light-source
+---
+
+## Consistent Shadow Direction Across UI
+
+All shadows must share the same offset direction to imply a single light source. Mixed directions feel broken.
+
+**Incorrect (conflicting light sources):**
+
+```css
+.card { box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); }
+.modal { box-shadow: 4px 0 8px rgba(0, 0, 0, 0.1); }
+.tooltip { box-shadow: 0 -4px 8px rgba(0, 0, 0, 0.1); }
+```
+
+**Correct (consistent top-down light):**
+
+```css
+.card { box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08); }
+.modal { box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12); }
+.tooltip { box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1); }
+```

--- a/.claude/skills/userinterface-wiki/rules/visual-shadow-matches-elevation.md
+++ b/.claude/skills/userinterface-wiki/rules/visual-shadow-matches-elevation.md
@@ -1,0 +1,23 @@
+---
+title: Shadow Size Indicates Elevation
+impact: MEDIUM
+tags: visual, shadow, elevation, hierarchy
+---
+
+## Shadow Size Indicates Elevation
+
+Larger blur and offset means higher elevation. Use a consistent shadow scale across your UI.
+
+**Correct (elevation scale):**
+
+```css
+:root {
+  --shadow-1: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-2: 0 2px 8px rgba(0, 0, 0, 0.08);
+  --shadow-3: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+.card { box-shadow: var(--shadow-1); }
+.dropdown { box-shadow: var(--shadow-2); }
+.modal { box-shadow: var(--shadow-3); }
+```

--- a/.claude/skills/userinterface-wiki/rules/weight-duration-matches-action.md
+++ b/.claude/skills/userinterface-wiki/rules/weight-duration-matches-action.md
@@ -1,0 +1,29 @@
+---
+title: Sound Duration Matches Action Duration
+impact: MEDIUM
+tags: weight, duration, action
+---
+
+## Sound Duration Matches Action Duration
+
+Sound duration should match action duration.
+
+**Incorrect (long sound for instant action):**
+
+```tsx
+function handleClick() {
+  playSound("long-whoosh"); // 2000ms
+}
+```
+
+**Correct (matched duration):**
+
+```tsx
+function handleClick() {
+  playSound("click"); // 50ms
+}
+
+function handleUpload() {
+  playSound("upload-progress"); // Matches upload duration
+}
+```

--- a/.claude/skills/userinterface-wiki/rules/weight-match-action.md
+++ b/.claude/skills/userinterface-wiki/rules/weight-match-action.md
@@ -1,0 +1,32 @@
+---
+title: Match Sound Weight to Action
+impact: MEDIUM
+tags: weight, action, importance
+---
+
+## Match Sound Weight to Action
+
+Sound weight should match action importance.
+
+**Incorrect (fanfare for toggle):**
+
+```tsx
+function handleToggle() {
+  playSound("triumphant-fanfare");
+  setEnabled(!enabled);
+}
+```
+
+**Correct (weight matches action):**
+
+```tsx
+function handleToggle() {
+  playSound("soft-click");
+  setEnabled(!enabled);
+}
+
+function handlePurchase() {
+  playSound("success-chime");
+  completePurchase();
+}
+```

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ jspm_packages/
 
 # Local AI tooling settings
 .claude/settings.local.json
+.agents/
 
 /forms_pro/public/frontend
 /forms_pro/www/forms.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ When a form is saved, its fields are synced to the linked DocType as `CustomFiel
 | Skill | Description |
 |---|---|
 | `/release [version]` | Draft a new GitHub release. Inspects merged PRs since the last release, categorizes them, and creates a draft on GitHub for review. |
+| `/add-field <FieldtypeName>` | Add a new field type end-to-end: backend doctype + mapping, submission serialization, frontend component, fieldTypes registry, options resolution, and submission display. |
 
 ## Key Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ When a form is saved, its fields are synced to the linked DocType as `CustomFiel
 |---|---|
 | `/release [version]` | Draft a new GitHub release. Inspects merged PRs since the last release, categorizes them, and creates a draft on GitHub for review. |
 | `/add-field <FieldtypeName>` | Add a new field type end-to-end: backend doctype + mapping, submission serialization, frontend component, fieldTypes registry, options resolution, and submission display. |
+| `/userinterface-wiki` | Review UI/UX against best practices — animations, CSS, typography, UX patterns, prefetching, icons. Outputs file:line findings. |
 
 > **Adding skills via `npx skills`:** Always use `--copy` and target `.claude/skills/` explicitly so Claude Code can discover them:
 > ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,12 @@ When a form is saved, its fields are synced to the linked DocType as `CustomFiel
 | `/release [version]` | Draft a new GitHub release. Inspects merged PRs since the last release, categorizes them, and creates a draft on GitHub for review. |
 | `/add-field <FieldtypeName>` | Add a new field type end-to-end: backend doctype + mapping, submission serialization, frontend component, fieldTypes registry, options resolution, and submission display. |
 
+> **Adding skills via `npx skills`:** Always use `--copy` and target `.claude/skills/` explicitly so Claude Code can discover them:
+> ```bash
+> npx skills add <source> --skill <name> -a claude-code --copy
+> ```
+> `.agents/` is gitignored — if a skill lands there, copy it to `.claude/skills/` manually.
+
 ## Key Conventions
 
 - **Python target**: 3.14+; formatted with `ruff`

--- a/forms_pro/api/submission.py
+++ b/forms_pro/api/submission.py
@@ -113,7 +113,8 @@ def _validate_form_response(form: "Form", form_data: dict) -> None:
             continue
 
         value = form_data.get(field.fieldname)
-        if is_required and (value is None or value == ""):
+        is_empty = value is None or value == "" or value == []
+        if is_required and is_empty:
             errors.append(_("{0} is required").format(field.label))
 
     if errors:
@@ -167,6 +168,11 @@ def submit_form_response(
 
         submission = frappe.new_doc(linked_doctype)
         for fieldname, value in form_data_dict.items():
+            # JSON fields (e.g. Multiselect) must be stored as a JSON string,
+            # but Frappe deserializes request body arrays into Python lists before
+            # we get here — serialize them back.
+            if isinstance(value, list):
+                value = json.dumps(value)
             submission.set(fieldname, value)
 
         submission.fp_linked_form = form_id

--- a/forms_pro/forms_pro/doctype/form_field/form_field.json
+++ b/forms_pro/forms_pro/doctype/form_field/form_field.json
@@ -37,7 +37,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Fieldtype",
-   "options": "Attach\nData\nNumber\nEmail\nDate\nDate Time\nDate Range\nTime Picker\nPassword\nSelect\nSwitch\nTextarea\nText Editor\nLink\nCheckbox\nRating\nPhone\nTable",
+   "options": "Attach\nData\nNumber\nEmail\nDate\nDate Time\nDate Range\nTime Picker\nPassword\nSelect\nSwitch\nTextarea\nText Editor\nLink\nCheckbox\nRating\nPhone\nTable\nMultiselect",
    "reqd": 1
   },
   {
@@ -81,7 +81,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-02-11 14:39:48.593350",
+ "modified": "2026-04-15 16:26:10.519579",
  "modified_by": "Administrator",
  "module": "Forms Pro",
  "name": "Form Field",

--- a/forms_pro/forms_pro/doctype/form_field/form_field.py
+++ b/forms_pro/forms_pro/doctype/form_field/form_field.py
@@ -28,6 +28,7 @@ FORM_TO_FRAPPE_FIELDTYPE: dict[str, dict] = {
     "Checkbox": {"fieldtype": "Check"},
     "Rating": {"fieldtype": "Rating"},
     "Table": {"fieldtype": "Table"},
+    "Multiselect": {"fieldtype": "JSON"},
 }
 
 
@@ -63,6 +64,7 @@ class FormField(Document):
             "Rating",
             "Phone",
             "Table",
+            "Multiselect",
         ]
         hidden: DF.Check
         label: DF.Data

--- a/frontend/e2e/helpers/form-builder.ts
+++ b/frontend/e2e/helpers/form-builder.ts
@@ -33,7 +33,18 @@ export class FormBuilderPage {
   }
 
   async publish() {
-    // Click Publish and wait for the label to flip to "Unpublish"
+    // After edits, form is dirty — header shows "Save" instead of "Publish".
+    // Save first so the Publish button becomes available.
+    const saveBtn = this.page.getByRole("button", {
+      name: "Save",
+      exact: true,
+    });
+    if (await saveBtn.isVisible()) {
+      await saveBtn.click();
+      await this.page
+        .getByRole("button", { name: /^publish$/i })
+        .waitFor({ timeout: 10000 });
+    }
     await this.page.getByRole("button", { name: /^publish$/i }).click();
     await this.page
       .getByRole("button", { name: /^unpublish$/i })

--- a/frontend/e2e/helpers/form-builder.ts
+++ b/frontend/e2e/helpers/form-builder.ts
@@ -41,9 +41,8 @@ export class FormBuilderPage {
     });
     if (await saveBtn.isVisible()) {
       await saveBtn.click();
-      await this.page
-        .getByRole("button", { name: /^publish$/i })
-        .waitFor({ timeout: 10000 });
+      // Wait for Save to disappear — same render cycle as Publish appearing
+      await saveBtn.waitFor({ state: "hidden", timeout: 30000 });
     }
     await this.page.getByRole("button", { name: /^publish$/i }).click();
     await this.page

--- a/frontend/e2e/specs/multiselect-field.spec.ts
+++ b/frontend/e2e/specs/multiselect-field.spec.ts
@@ -13,6 +13,9 @@ test.describe("Multiselect field", () => {
     const builder = new FormBuilderPage(page);
     await builder.goto(formId);
 
+    // Set a form title so Save doesn't fail with MandatoryError (title is required)
+    await page.getByPlaceholder("Untitled Form").fill("Multiselect Test Form");
+
     // Add Multiselect field from sidebar; wait for canvas extras to confirm render
     await builder.addField("Multiselect");
     await expect(page.getByRole("button", { name: "Add Option" })).toBeVisible({

--- a/frontend/e2e/specs/multiselect-field.spec.ts
+++ b/frontend/e2e/specs/multiselect-field.spec.ts
@@ -25,6 +25,9 @@ test.describe("Multiselect field", () => {
     // Add three options via the builder extras button
     const options = ["Option A", "Option B", "Option C"];
     for (const option of options) {
+      await expect(
+        page.getByRole("button", { name: "Add Option" })
+      ).toBeVisible({ timeout: 5000 });
       await page.getByRole("button", { name: "Add Option" }).click();
       await page.getByPlaceholder("Type option and press Enter").fill(option);
       await page.keyboard.press("Enter");

--- a/frontend/e2e/specs/multiselect-field.spec.ts
+++ b/frontend/e2e/specs/multiselect-field.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "../fixtures/test-data.fixture";
+import { FormBuilderPage } from "../helpers/form-builder";
+import { SubmissionPage } from "../helpers/submission";
+
+test.describe("Multiselect field", () => {
+  test("add options in builder, publish, submit via public form", async ({
+    page,
+    browser,
+    createForm,
+    apiContext,
+  }) => {
+    const formId = await createForm();
+    const builder = new FormBuilderPage(page);
+    await builder.goto(formId);
+
+    // Add Multiselect field from sidebar
+    await builder.addField("Multiselect");
+
+    // Add three options via the builder extras button
+    const options = ["Option A", "Option B", "Option C"];
+    for (const option of options) {
+      await page.getByRole("button", { name: "Add Option" }).click();
+      await page.getByPlaceholder("Type option and press Enter").fill(option);
+      await page.keyboard.press("Enter");
+    }
+
+    // Publish — assert no error toast appears
+    await builder.publish();
+    await expect(
+      page.locator("[data-sonner-toast][data-type='error']")
+    ).not.toBeVisible();
+
+    // Fetch the public route
+    const res = await apiContext.get(`/api/resource/Form/${formId}`);
+    const { data } = await res.json();
+    const route: string = data.route;
+
+    // Open as guest
+    const guestCtx = await browser.newContext();
+    const guestPage = await guestCtx.newPage();
+    const submissionPage = new SubmissionPage(guestPage);
+
+    await submissionPage.goto(route);
+    await expect(guestPage.getByRole("button", { name: "Submit" })).toBeVisible(
+      { timeout: 10000 }
+    );
+
+    // Select two options
+    await guestPage.locator("label", { hasText: "Option A" }).click();
+    await guestPage.locator("label", { hasText: "Option B" }).click();
+
+    await submissionPage.submit();
+
+    await expect(submissionPage.successMessage()).toBeVisible({
+      timeout: 10000,
+    });
+
+    await guestCtx.close();
+  });
+});

--- a/frontend/e2e/specs/multiselect-field.spec.ts
+++ b/frontend/e2e/specs/multiselect-field.spec.ts
@@ -15,7 +15,7 @@ test.describe("Multiselect field", () => {
 
     // Add Multiselect field from sidebar; wait for it to land on canvas
     await builder.addField("Multiselect");
-    await expect(page.getByText("No options defined")).toBeVisible({
+    await expect(page.getByText("No options defined").first()).toBeVisible({
       timeout: 10000,
     });
 

--- a/frontend/e2e/specs/multiselect-field.spec.ts
+++ b/frontend/e2e/specs/multiselect-field.spec.ts
@@ -13,8 +13,14 @@ test.describe("Multiselect field", () => {
     const builder = new FormBuilderPage(page);
     await builder.goto(formId);
 
-    // Add Multiselect field from sidebar
+    // Add Multiselect field from sidebar; wait for it to land on canvas
     await builder.addField("Multiselect");
+    await expect(page.getByText("No options defined")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Set a label
+    await page.getByPlaceholder("Label").fill("Favourite Colors");
 
     // Add three options via the builder extras button
     const options = ["Option A", "Option B", "Option C"];

--- a/frontend/e2e/specs/multiselect-field.spec.ts
+++ b/frontend/e2e/specs/multiselect-field.spec.ts
@@ -13,9 +13,9 @@ test.describe("Multiselect field", () => {
     const builder = new FormBuilderPage(page);
     await builder.goto(formId);
 
-    // Add Multiselect field from sidebar; wait for it to land on canvas
+    // Add Multiselect field from sidebar; wait for canvas extras to confirm render
     await builder.addField("Multiselect");
-    await expect(page.getByText("No options defined").first()).toBeVisible({
+    await expect(page.getByRole("button", { name: "Add Option" })).toBeVisible({
       timeout: 10000,
     });
 

--- a/frontend/src/components/builder/FieldRenderer.vue
+++ b/frontend/src/components/builder/FieldRenderer.vue
@@ -65,7 +65,7 @@ const { options: selectOptions } = useFieldOptions(fieldData);
         </div>
     </div>
 
-    <!-- description-first: Text Editor — description sits above the input -->
+    <!-- description-first: label → description → input (Text Editor, Multiselect) -->
     <div v-else-if="layout === 'description-first'" class="flex flex-col gap-1">
         <FieldLabel
             :field="fieldData"
@@ -78,6 +78,12 @@ const { options: selectOptions } = useFieldOptions(fieldData);
             :field="fieldData"
             :class="{ 'pointer-events-none': inEditMode }"
             :disabled="disabled"
+        />
+        <component
+            v-if="inEditMode && builderExtrasComponent"
+            :is="builderExtrasComponent"
+            :field="fieldData"
+            @update:field="fieldData = $event"
         />
     </div>
 

--- a/frontend/src/components/builder/FieldRenderer.vue
+++ b/frontend/src/components/builder/FieldRenderer.vue
@@ -47,92 +47,89 @@ const { options: selectOptions } = useFieldOptions(fieldData);
 </script>
 
 <template>
-    <!-- inline: Switch / Checkbox — input precedes label -->
-    <div v-if="layout === 'inline'" class="w-full flex gap-2 my-2">
-        <RenderField
-            v-model="modelValue"
-            :field="fieldData"
-            :class="{ 'pointer-events-none mt-1': inEditMode }"
-            :disabled="disabled"
-        />
-        <div class="flex flex-col gap-1 w-full">
+    <div class="w-full flex flex-col gap-2">
+        <!-- inline: Switch / Checkbox — input precedes label -->
+        <div v-if="layout === 'inline'" class="w-full flex gap-2 my-2">
+            <RenderField
+                v-model="modelValue"
+                :field="fieldData"
+                :class="{ 'pointer-events-none mt-1': inEditMode }"
+                :disabled="disabled"
+            />
+            <div class="flex flex-col gap-1 w-full">
+                <FieldLabel
+                    :field="fieldData"
+                    :in-edit-mode="inEditMode"
+                    @update:label="fieldData.label = $event"
+                />
+                <small class="text-gray-500">{{ fieldData.description }}</small>
+            </div>
+        </div>
+
+        <!-- description-first: label → description → input (Text Editor, Multiselect) -->
+        <div v-else-if="layout === 'description-first'" class="flex flex-col gap-1">
             <FieldLabel
                 :field="fieldData"
                 :in-edit-mode="inEditMode"
                 @update:label="fieldData.label = $event"
             />
             <small class="text-gray-500">{{ fieldData.description }}</small>
+            <RenderField
+                v-model="modelValue"
+                :field="fieldData"
+                :class="{ 'pointer-events-none': inEditMode }"
+                :disabled="disabled"
+            />
         </div>
-    </div>
 
-    <!-- description-first: label → description → input (Text Editor, Multiselect) -->
-    <div v-else-if="layout === 'description-first'" class="flex flex-col gap-1">
-        <FieldLabel
-            :field="fieldData"
-            :in-edit-mode="inEditMode"
-            @update:label="fieldData.label = $event"
-        />
-        <small class="text-gray-500">{{ fieldData.description }}</small>
-        <RenderField
-            v-model="modelValue"
-            :field="fieldData"
-            :class="{ 'pointer-events-none': inEditMode }"
-            :disabled="disabled"
-        />
+        <!-- custom: Attach and Table each need their own binding/widget -->
+        <div v-else-if="layout === 'custom' && fieldData.fieldtype === 'Attach'">
+            <FieldLabel
+                :field="fieldData"
+                :in-edit-mode="inEditMode"
+                @update:label="fieldData.label = $event"
+            />
+            <RenderField
+                v-model="modelValue"
+                :field="fieldData"
+                :class="{ 'pointer-events-none': inEditMode }"
+                :disabled="disabled"
+            />
+            <small class="text-gray-500">{{ fieldData.description }}</small>
+        </div>
+
+        <div v-else-if="layout === 'custom'" class="w-full space-y-4">
+            <FieldLabel
+                :field="fieldData"
+                :in-edit-mode="inEditMode"
+                @update:label="fieldData.label = $event"
+            />
+            <small class="text-gray-500">{{ fieldData.description }}</small>
+            <Table v-model="modelValue" :in-edit-mode="inEditMode" :doctype="fieldData.options" />
+        </div>
+
+        <!-- default: label → input → description -->
+        <div v-else class="w-full flex flex-col gap-2">
+            <FieldLabel
+                :field="fieldData"
+                :in-edit-mode="inEditMode"
+                @update:label="fieldData.label = $event"
+            />
+            <RenderField
+                v-model="modelValue"
+                :field="fieldData"
+                :class="{ 'pointer-events-none': inEditMode }"
+                :disabled="disabled"
+                :options="selectOptions"
+            />
+            <small class="text-gray-500">{{ fieldData.description }}</small>
+        </div>
+
         <component
             v-if="inEditMode && builderExtrasComponent"
             :is="builderExtrasComponent"
             :field="fieldData"
             @update:field="fieldData = $event"
         />
-    </div>
-
-    <!-- custom: Attach and Table each need their own binding/widget -->
-    <div v-else-if="layout === 'custom' && fieldData.fieldtype === 'Attach'">
-        <FieldLabel
-            :field="fieldData"
-            :in-edit-mode="inEditMode"
-            @update:label="fieldData.label = $event"
-        />
-        <RenderField
-            v-model="modelValue"
-            :field="fieldData"
-            :class="{ 'pointer-events-none': inEditMode }"
-            :disabled="disabled"
-        />
-        <small class="text-gray-500">{{ fieldData.description }}</small>
-    </div>
-
-    <div v-else-if="layout === 'custom'" class="w-full space-y-4">
-        <FieldLabel
-            :field="fieldData"
-            :in-edit-mode="inEditMode"
-            @update:label="fieldData.label = $event"
-        />
-        <small class="text-gray-500">{{ fieldData.description }}</small>
-        <Table v-model="modelValue" :in-edit-mode="inEditMode" :doctype="fieldData.options" />
-    </div>
-
-    <!-- default: label → input → description -->
-    <div v-else class="w-full flex flex-col gap-2">
-        <FieldLabel
-            :field="fieldData"
-            :in-edit-mode="inEditMode"
-            @update:label="fieldData.label = $event"
-        />
-        <RenderField
-            v-model="modelValue"
-            :field="fieldData"
-            :class="{ 'pointer-events-none': inEditMode }"
-            :disabled="disabled"
-            :options="selectOptions"
-        />
-        <component
-            v-if="inEditMode && builderExtrasComponent"
-            :is="builderExtrasComponent"
-            :field="fieldData"
-            @update:field="fieldData = $event"
-        />
-        <small class="text-gray-500">{{ fieldData.description }}</small>
     </div>
 </template>

--- a/frontend/src/components/builder/FieldRenderer.vue
+++ b/frontend/src/components/builder/FieldRenderer.vue
@@ -39,6 +39,10 @@ const layout = computed(
     () => getFieldTypeDef(fieldData.value.fieldtype as Fieldtype)?.layout ?? "default"
 );
 
+const builderExtrasComponent = computed(
+    () => getFieldTypeDef(fieldData.value.fieldtype as Fieldtype)?.builderExtras ?? null
+);
+
 const { options: selectOptions } = useFieldOptions(fieldData);
 </script>
 
@@ -116,6 +120,12 @@ const { options: selectOptions } = useFieldOptions(fieldData);
             :class="{ 'pointer-events-none': inEditMode }"
             :disabled="disabled"
             :options="selectOptions"
+        />
+        <component
+            v-if="inEditMode && builderExtrasComponent"
+            :is="builderExtrasComponent"
+            :field="fieldData"
+            @update:field="fieldData = $event"
         />
         <small class="text-gray-500">{{ fieldData.description }}</small>
     </div>

--- a/frontend/src/components/fields/Multiselect.vue
+++ b/frontend/src/components/fields/Multiselect.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+const props = defineProps<{
+    options?: string[];
+    disabled?: boolean;
+}>();
+
+const modelValue = defineModel<string[]>({ default: () => [] });
+
+const selected = computed({
+    get() {
+        return Array.isArray(modelValue.value) ? modelValue.value : [];
+    },
+    set(val: string[]) {
+        modelValue.value = val;
+    },
+});
+
+function toggle(option: string) {
+    if (props.disabled) return;
+    const current = selected.value;
+    if (current.includes(option)) {
+        selected.value = current.filter((v) => v !== option);
+    } else {
+        selected.value = [...current, option];
+    }
+}
+</script>
+
+<template>
+    <div class="flex flex-col gap-2">
+        <label
+            v-for="option in options"
+            :key="option"
+            class="flex items-center gap-2 cursor-pointer"
+            :class="{ 'opacity-50 cursor-not-allowed': disabled }"
+        >
+            <input
+                type="checkbox"
+                :value="option"
+                :checked="selected.includes(option)"
+                :disabled="disabled"
+                class="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                @change="toggle(option)"
+            />
+            <span class="text-sm text-ink-gray-7">{{ option }}</span>
+        </label>
+        <span v-if="!options?.length" class="text-sm text-ink-gray-4 italic">
+            No options defined
+        </span>
+    </div>
+</template>

--- a/frontend/src/components/fields/multiselect/Multiselect.vue
+++ b/frontend/src/components/fields/multiselect/Multiselect.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
+import { Checkbox } from "frappe-ui";
 
 const props = defineProps<{
     options?: string[];
@@ -17,34 +18,30 @@ const selected = computed({
     },
 });
 
-function toggle(option: string) {
-    if (props.disabled) return;
-    const current = selected.value;
-    if (current.includes(option)) {
-        selected.value = current.filter((v) => v !== option);
+function toggle(option: string, checked: boolean) {
+    if (checked) {
+        selected.value = [...selected.value, option];
     } else {
-        selected.value = [...current, option];
+        selected.value = selected.value.filter((v) => v !== option);
     }
 }
 </script>
 
 <template>
-    <div class="flex flex-col gap-2">
+    <div class="flex flex-col gap-1">
         <label
             v-for="option in options"
             :key="option"
-            class="flex items-center gap-2 cursor-pointer"
+            class="flex items-center gap-2 min-h-[32px] rounded px-1 cursor-pointer hover:bg-surface-gray-2 active:bg-surface-gray-3 transition"
             :class="{ 'opacity-50 cursor-not-allowed': disabled }"
         >
-            <input
-                type="checkbox"
-                :value="option"
-                :checked="selected.includes(option)"
+            <Checkbox
+                :modelValue="selected.includes(option)"
                 :disabled="disabled"
-                class="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                @change="toggle(option)"
+                size="sm"
+                @update:modelValue="toggle(option, $event)"
             />
-            <span class="text-sm text-ink-gray-7">{{ option }}</span>
+            <span class="text-base text-ink-gray-8 select-none">{{ option }}</span>
         </label>
         <span v-if="!options?.length" class="text-sm text-ink-gray-4 italic">
             No options defined

--- a/frontend/src/components/fields/multiselect/MultiselectBuilderExtras.vue
+++ b/frontend/src/components/fields/multiselect/MultiselectBuilderExtras.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, nextTick } from "vue";
-import { FormControl } from "frappe-ui"; // Button is globally registered in main.ts
+import { FormControl, ErrorMessage } from "frappe-ui";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const props = defineProps<{ field: Record<string, any> }>();
@@ -16,20 +16,39 @@ async function startAddingOption() {
     newOptionInput.value?.$el?.querySelector("input")?.focus();
 }
 
+const errorMessage = ref("");
+
+function dismissIfEmpty() {
+    if (!newOptionValue.value.trim()) {
+        isAddingOption.value = false;
+        errorMessage.value = "";
+    }
+}
+
 function addOption() {
+    errorMessage.value = "";
+
     const value = newOptionValue.value.trim();
     if (!value) return;
 
-    const current = props.field.options ?? "";
+    const items = new Set((props.field.options ?? "").split("\n").filter(Boolean));
+
+    if (items.has(value)) {
+        errorMessage.value = "This option already exists in the list";
+        return;
+    }
+
+    items.add(value);
     emit("update:field", {
         ...props.field,
-        options: current ? `${current}\n${value}` : value,
+        options: [...items].join("\n"),
     });
     newOptionValue.value = "";
 }
 </script>
 
 <template>
+    <ErrorMessage class="text-xs" :message="errorMessage" />
     <FormControl
         v-if="isAddingOption"
         ref="newOptionInput"
@@ -40,9 +59,11 @@ function addOption() {
         placeholder="Type option and press Enter"
         @keydown.enter.prevent="addOption"
         @keydown.escape="isAddingOption = false"
+        @blur="dismissIfEmpty"
     />
     <Button
         v-else
+        class="w-fit"
         variant="ghost"
         label="Add Option"
         icon-left="plus"

--- a/frontend/src/components/fields/multiselect/MultiselectBuilderExtras.vue
+++ b/frontend/src/components/fields/multiselect/MultiselectBuilderExtras.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { ref, nextTick } from "vue";
+import { FormControl } from "frappe-ui"; // Button is globally registered in main.ts
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const props = defineProps<{ field: Record<string, any> }>();
+const emit = defineEmits<{ (e: "update:field", value: typeof props.field): void }>();
+
+const isAddingOption = ref(false);
+const newOptionValue = ref("");
+const newOptionInput = ref<InstanceType<typeof FormControl> | null>(null);
+
+async function startAddingOption() {
+    isAddingOption.value = true;
+    await nextTick();
+    newOptionInput.value?.$el?.querySelector("input")?.focus();
+}
+
+function addOption() {
+    const value = newOptionValue.value.trim();
+    if (!value) return;
+
+    const current = props.field.options ?? "";
+    emit("update:field", {
+        ...props.field,
+        options: current ? `${current}\n${value}` : value,
+    });
+    newOptionValue.value = "";
+}
+</script>
+
+<template>
+    <FormControl
+        v-if="isAddingOption"
+        ref="newOptionInput"
+        v-model="newOptionValue"
+        type="text"
+        variant="outline"
+        size="sm"
+        placeholder="Type option and press Enter"
+        @keydown.enter.prevent="addOption"
+        @keydown.escape="isAddingOption = false"
+    />
+    <Button
+        v-else
+        variant="ghost"
+        label="Add Option"
+        icon-left="plus"
+        @click="startAddingOption"
+    />
+</template>

--- a/frontend/src/components/fields/multiselect/MultiselectBuilderExtras.vue
+++ b/frontend/src/components/fields/multiselect/MultiselectBuilderExtras.vue
@@ -44,6 +44,7 @@ function addOption() {
         options: [...items].join("\n"),
     });
     newOptionValue.value = "";
+    isAddingOption.value = false;
 }
 </script>
 

--- a/frontend/src/components/form/submissions/SubmissionFieldValue.vue
+++ b/frontend/src/components/form/submissions/SubmissionFieldValue.vue
@@ -40,6 +40,17 @@ const formattedDateValue = computed(() => {
 const typeDef = computed(() => getFieldTypeDef(props.fieldtype));
 const isDateField = computed(() => typeDef.value?.isDate ?? false);
 
+const parsedMultiselectValue = computed(() => {
+    if (!props.value) return "–";
+    try {
+        const parsed = JSON.parse(props.value);
+        if (Array.isArray(parsed)) return parsed.join(", ");
+    } catch {
+        // value might already be a readable string
+    }
+    return String(props.value);
+});
+
 // Only allow safe attachment URLs (relative Frappe paths or http/https).
 // Rejects javascript: and other unsafe schemes.
 const safeAttachUrl = computed<string | null>(() => {
@@ -100,6 +111,10 @@ const classNames = computed<string>(() =>
         </a>
         <span v-else-if="fieldtype === Fieldtype.ATTACH && value" class="text-sm text-ink-gray-5">
             {{ value }}
+        </span>
+
+        <span v-else-if="fieldtype === Fieldtype.MULTISELECT" class="text-sm text-ink-gray-7">
+            {{ parsedMultiselectValue }}
         </span>
 
         <span

--- a/frontend/src/config/fieldTypes.ts
+++ b/frontend/src/config/fieldTypes.ts
@@ -265,7 +265,7 @@ export const FIELD_TYPE_DEFINITIONS: FieldTypeDefinition[] = [
     name: Fieldtype.MULTISELECT,
     component: Multiselect,
     props: {},
-    layout: "default",
+    layout: "description-first",
     frappeFieldtype: "JSON",
     isBoolean: false,
     isDate: false,

--- a/frontend/src/config/fieldTypes.ts
+++ b/frontend/src/config/fieldTypes.ts
@@ -34,6 +34,7 @@ import {
   FormControl,
 } from "frappe-ui";
 import Attachment from "@/components/fields/Attachment.vue";
+import Multiselect from "@/components/fields/Multiselect.vue";
 import Phone from "@/components/fields/Phone.vue";
 import Table from "@/components/fields/Table.vue";
 import { Fieldtype } from "@/types/FormsPro/form_field.types";
@@ -250,6 +251,15 @@ export const FIELD_TYPE_DEFINITIONS: FieldTypeDefinition[] = [
     },
     layout: "custom",
     frappeFieldtype: "Table",
+    isBoolean: false,
+    isDate: false,
+  },
+  {
+    name: Fieldtype.MULTISELECT,
+    component: Multiselect,
+    props: {},
+    layout: "default",
+    frappeFieldtype: "JSON",
     isBoolean: false,
     isDate: false,
   },

--- a/frontend/src/config/fieldTypes.ts
+++ b/frontend/src/config/fieldTypes.ts
@@ -34,7 +34,8 @@ import {
   FormControl,
 } from "frappe-ui";
 import Attachment from "@/components/fields/Attachment.vue";
-import Multiselect from "@/components/fields/Multiselect.vue";
+import Multiselect from "@/components/fields/multiselect/Multiselect.vue";
+import MultiselectBuilderExtras from "@/components/fields/multiselect/MultiselectBuilderExtras.vue";
 import Phone from "@/components/fields/Phone.vue";
 import Table from "@/components/fields/Table.vue";
 import { Fieldtype } from "@/types/FormsPro/form_field.types";
@@ -268,6 +269,7 @@ export const FIELD_TYPE_DEFINITIONS: FieldTypeDefinition[] = [
     frappeFieldtype: "JSON",
     isBoolean: false,
     isDate: false,
+    builderExtras: MultiselectBuilderExtras,
   },
 ];
 

--- a/frontend/src/config/fieldTypes.ts
+++ b/frontend/src/config/fieldTypes.ts
@@ -68,6 +68,12 @@ export type FieldTypeDefinition = {
   isBoolean: boolean;
   /** True for Date / DateTime / DateRange / TimePicker — affects display formatting */
   isDate: boolean;
+  /**
+   * Optional component rendered below the input widget when the form builder
+   * is in edit mode. Receives `:field` (the field object) and emits `update:field`.
+   * Use for builder-only controls like "Add Option".
+   */
+  builderExtras?: Component;
 };
 
 export const FIELD_TYPE_DEFINITIONS: FieldTypeDefinition[] = [

--- a/frontend/src/types/FormsPro/form_field.types.ts
+++ b/frontend/src/types/FormsPro/form_field.types.ts
@@ -17,6 +17,7 @@ export enum Fieldtype {
   "RATING" = "Rating",
   "PHONE" = "Phone",
   "TABLE" = "Table",
+  "MULTISELECT" = "Multiselect",
 }
 
 export interface FormField {

--- a/frontend/src/utils/selectOptions.ts
+++ b/frontend/src/utils/selectOptions.ts
@@ -24,7 +24,7 @@ export async function getFieldOptions(
     return "";
   }
 
-  if (field.fieldtype === "Select") {
+  if (field.fieldtype === "Select" || field.fieldtype === "Multiselect") {
     return field.options.split("\n");
   }
 


### PR DESCRIPTION
## What

Adds a **Multiselect** field type to the form builder — a checklist of options the submitter can pick multiple values from.

Also introduces a general pattern for **builder-only extras**: field-specific UI that appears in the form builder beneath the field widget (e.g. the "Add Option" control), without hardcoding any field-type logic in `FieldRenderer`.

## Changes

### New field type: Multiselect
- Renders as a list of checkboxes (frappe-ui `Checkbox`)
- Duplicate detection and error feedback when adding options
- Values serialized to JSON on submission (stored as `JSON` Frappe fieldtype)

### Builder extras pattern (`builderExtras` in fieldTypes registry)
- `FieldTypeDefinition` now has an optional `builderExtras?: Component` slot
- `FieldRenderer` reads this from the registry and renders it below the field — no per-type `v-if` branches
- `FieldRenderer` template wrapped in a single root div so extras always stack correctly regardless of layout

### File structure
- Fields with builder extras graduate to a subfolder: `fields/multiselect/Multiselect.vue` + `fields/multiselect/MultiselectBuilderExtras.vue`
- Fields without extras stay as flat files

## Adding builder extras to a future field type

1. Create `frontend/src/components/fields/<name>/<Name>BuilderExtras.vue` (receives `:field`, emits `update:field`)
2. Add `builderExtras: YourComponent` to its entry in `FIELD_TYPE_DEFINITIONS` in `fieldTypes.ts`

That's it — `FieldRenderer` needs no changes.