### PR TITLE
fix(e2e): auto-fill form title in FormBuilderPage.goto() to prevent MandatoryError

### DIFF
--- a/frontend/e2e/fixtures/test-data.fixture.ts
+++ b/frontend/e2e/fixtures/test-data.fixture.ts
@@ -69,9 +69,9 @@ export const test = base.extend<TestDataFixtures>({
       const formId = message.form_document as string;
       created.push(formId);
 
-      // Publish the form via Frappe REST API
+      // Publish the form via Frappe REST API (also set title to avoid "Untitled Form" transform)
       const publishRes = await apiContext.put(`/api/resource/Form/${formId}`, {
-        data: { is_published: 1 },
+        data: { is_published: 1, title: `E2E Published Form ${Date.now()}` },
       });
       const publishData = await publishRes.json();
       const route = publishData.data?.route as string;

--- a/frontend/e2e/helpers/form-builder.ts
+++ b/frontend/e2e/helpers/form-builder.ts
@@ -3,12 +3,33 @@ import type { Page } from "@playwright/test";
 export class FormBuilderPage {
   constructor(private page: Page) {}
 
-  async goto(formId: string) {
+  async goto(
+    formId: string,
+    options?: { title?: string; skipTitleFill?: boolean }
+  ) {
     await this.page.goto(`/forms/edit-form/${formId}`);
     // Wait for the sidebar to confirm the builder is mounted
     await this.page.waitForSelector(
       '[data-form-builder-component="form-builder-sidebar"]'
     );
+
+    if (options?.skipTitleFill) return;
+
+    // Set unique title to avoid MandatoryError on save (frontend transforms "Untitled Form" → "")
+    const title = options?.title ?? `E2E Form ${Date.now()}`;
+    await this.page.getByPlaceholder("Untitled Form").fill(title);
+
+    // Save immediately so form is clean and Publish/Unpublish button shows
+    const saveBtn = this.page.getByRole("button", {
+      name: "Save",
+      exact: true,
+    });
+    // Wait briefly for dirty state to propagate
+    await this.page.waitForTimeout(200);
+    if (await saveBtn.isVisible()) {
+      await saveBtn.click();
+      await saveBtn.waitFor({ state: "hidden", timeout: 30000 });
+    }
   }
 
   // Scope selectors to the sidebar (which has a stable pre-existing attribute)

--- a/frontend/e2e/specs/form-creation.spec.ts
+++ b/frontend/e2e/specs/form-creation.spec.ts
@@ -58,7 +58,8 @@ test.describe("Form Creation", () => {
   }) => {
     const { formId } = await createPublishedForm();
     const builder = new FormBuilderPage(page);
-    await builder.goto(formId);
+    // skipTitleFill: createPublishedForm already set title, don't make form dirty
+    await builder.goto(formId, { skipTitleFill: true });
 
     // Published form → Unpublish button visible
     await expect(

--- a/frontend/e2e/specs/multiselect-field.spec.ts
+++ b/frontend/e2e/specs/multiselect-field.spec.ts
@@ -13,9 +13,6 @@ test.describe("Multiselect field", () => {
     const builder = new FormBuilderPage(page);
     await builder.goto(formId);
 
-    // Set a form title so Save doesn't fail with MandatoryError (title is required)
-    await page.getByPlaceholder("Untitled Form").fill("Multiselect Test Form");
-
     // Add Multiselect field from sidebar; wait for canvas extras to confirm render
     await builder.addField("Multiselect");
     await expect(page.getByRole("button", { name: "Add Option" })).toBeVisible({


### PR DESCRIPTION
## Summary
- `FormBuilderPage.goto()` now auto-fills unique title and saves to prevent `MandatoryError` on form save
- `createPublishedForm` fixture sets title alongside `is_published`
- Removed manual title fill workaround from `multiselect-field.spec.ts`

## Problem
Forms created via e2e fixtures have title "Untitled Form" which the frontend transforms to "" on load. When tests modify the form and save, the blank title causes a `MandatoryError`. This was causing CI failures.

## Test plan
- [x] All 14 e2e tests pass locally
- [x] `multiselect-field.spec.ts` passes without manual title fill
- [x] `can publish a draft form` test passes
- [x] `can unpublish a published form` test passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced form publication testing with explicit title handling in API payloads.
  * Improved form builder page navigation with flexible title initialization options.
  * Refined test infrastructure for form creation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->