### PR TITLE
ci: add merge_group trigger to enable GitHub merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
   pull_request:
+  merge_group:
 
 concurrency:
   group: develop-forms_pro-${{ github.event.number }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -2,6 +2,7 @@ name: Linters
 
 on:
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 permissions:
@@ -15,7 +16,7 @@ jobs:
   linter:
     name: 'Frappe Linter'
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - "frontend/**"
       - ".github/workflows/typecheck.yml"
+  merge_group:
 
 concurrency:
   group: typecheck-forms_pro-${{ github.event.number || github.sha }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Add `merge_group` trigger to CI, linter, typecheck, and UI test workflows
- Enables GitHub merge queue to run CI checks on merged code before actually merging
- Fix linter job condition to also run on `merge_group` events

## Setup required
After merging, enable merge queue in **Settings → Rulesets**:
1. Enable "Require merge queue"
2. Add required status checks: `Server`, `Frappe Linter`, `TypeScript`, `Playwright E2E`

🤖 Generated with [Claude Code](https://claude.ai/code)