### PR TITLE
ci: add backport workflow for version-15 branch

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,15 @@
+name: Backport
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+jobs:
+  backport:
+    if: github.event.pull_request.merged && contains(github.event.pull_request.labels.*.name, 'backport/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: korthout/backport-action@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pull_title: "[backport] ${pull_title}"


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow using `korthout/backport-action`
- When PR merged to `develop` with `backport/version-15` label, auto-creates backport PR targeting `version-15`
- Label `backport/version-15` already created on repo

## Usage
1. Add `backport/version-15` label to any PR (before or after merge)
2. On merge → action cherry-picks and creates new PR to version-15
3. If conflicts → creates draft PR with manual resolution instructions

## Test plan
- [ ] Merge this PR with `backport/version-15` label
- [ ] Verify backport PR auto-created to version-15

🤖 Generated with [Claude Code](https://claude.ai/claude-code)