### PR TITLE
fix(Form): correct initial route generation string

### DIFF
--- a/forms_pro/forms_pro/doctype/form/form.py
+++ b/forms_pro/forms_pro/doctype/form/form.py
@@ -51,7 +51,7 @@ class Form(Document):
         return users_shared_with
 
     def generate_initial_route(self) -> str:
-        return "s/forms_pro_" + frappe.utils.random_string(8)
+        return "forms_pro_" + frappe.utils.random_string(8)
 
     def before_insert(self) -> None:
         self.status = "Draft"


### PR DESCRIPTION
- Updated the initial route generation method to remove the unnecessary 's/' prefix, ensuring the route is generated correctly as 'forms_pro_' followed by a random string.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated form route generation to provide cleaner URL formatting for newly created forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->