### PR TITLE
fix: prevent duplicate fieldnames on form save

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import "vue-sonner/style.css";
 import { Toaster } from "vue-sonner";
+import GlobalDialog from "@/components/ui/GlobalDialog.vue";
 import { useUser } from "@/stores/user";
 
 const userStore = useUser();
@@ -12,4 +13,5 @@ userStore.initialize();
         <router-view />
     </div>
     <Toaster theme="system" />
+    <GlobalDialog />
 </template>

--- a/frontend/src/components/ui/GlobalDialog.vue
+++ b/frontend/src/components/ui/GlobalDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { Dialog, Button } from "frappe-ui";
-import { dialogState, dialog } from "@/utils/dialog";
+import { Dialog } from "frappe-ui";
+import { dialogState } from "@/utils/dialog";
 </script>
 
 <template>
@@ -12,7 +12,14 @@ import { dialogState, dialog } from "@/utils/dialog";
         }"
     >
         <template #body-content>
-            <p class="text-p-base text-gray-700">{{ dialogState.message }}</p>
+            <p
+                v-if="dialogState.html"
+                class="text-p-base text-gray-700"
+                v-html="dialogState.message"
+            ></p>
+            <p v-else class="text-p-base text-gray-700">
+                {{ dialogState.message }}
+            </p>
         </template>
     </Dialog>
 </template>

--- a/frontend/src/components/ui/GlobalDialog.vue
+++ b/frontend/src/components/ui/GlobalDialog.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { Dialog, Button } from "frappe-ui";
+import { dialogState, dialog } from "@/utils/dialog";
+</script>
+
+<template>
+    <Dialog
+        v-model="dialogState.open"
+        :options="{
+            title: dialogState.title,
+            actions: dialogState.actions,
+        }"
+    >
+        <template #body-content>
+            <p class="text-p-base text-gray-700">{{ dialogState.message }}</p>
+        </template>
+    </Dialog>
+</template>

--- a/frontend/src/stores/editForm.ts
+++ b/frontend/src/stores/editForm.ts
@@ -5,6 +5,7 @@ import { mapDoctypeFieldForForm } from "@/utils/form_fields";
 import { FormField, Fieldtype } from "@/types/formfield";
 import { Form } from "@/types/form";
 import { toast } from "vue-sonner";
+import { dialog } from "@/utils/dialog";
 
 function scrubFieldname(label: string) {
   return label
@@ -90,30 +91,65 @@ export const useEditForm = defineStore("editForm", () => {
     formResource.value = null;
   }
 
-  function save() {
-    if (formResource.value) {
-      formResource.value.doc.fields.forEach(
-        (field: FormField, index: number) => {
-          field.idx = index + 1;
-          if (!field.fieldname || field.fieldname.trim() === "") {
-            field.fieldname = scrubFieldname(field.label);
-          }
-        }
-      );
+  function findDuplicateFieldnames(): { label: string; fieldname: string }[] {
+    const allFields = formResource.value?.doc?.fields || [];
+    const seen = new Map<string, FormField>();
+    const duplicates: { label: string; fieldname: string }[] = [];
 
-      return formResource.value.setValue.submit(formResource.value.doc, {
-        onSuccess: () => {
-          toast.success("Form Updated Successfully");
-        },
-        onError: (error: any) => {
-          toast.error("Failed to Update Form", {
-            description: error.message,
-          });
-        },
-      });
+    for (const field of allFields) {
+      const name = field.fieldname?.trim()
+        ? field.fieldname
+        : scrubFieldname(field.label);
+
+      if (seen.has(name)) {
+        const existing = seen.get(name)!;
+        if (!duplicates.some((d) => d.fieldname === name)) {
+          duplicates.push({ label: existing.label, fieldname: name });
+        }
+        duplicates.push({ label: field.label, fieldname: name });
+      }
+      seen.set(name, field);
     }
-    toast.error("No form resource available");
-    return Promise.reject(new Error("No form resource available"));
+
+    return duplicates;
+  }
+
+  async function save() {
+    if (!formResource.value) {
+      toast.error("No form resource available");
+      return Promise.reject(new Error("No form resource available"));
+    }
+
+    const duplicates = findDuplicateFieldnames();
+    if (duplicates.length > 0) {
+      const fieldList = duplicates
+        .map((d) => `<b>${d.label} (${d.fieldname})</b>`)
+        .join(", ");
+      await dialog.alert({
+        title: "Duplicate Fieldnames",
+        message: `These fields will have duplicate fieldnames: ${fieldList}. Please change one of the labels or set a unique fieldname.`,
+        html: true,
+      });
+      return Promise.reject(new Error("Duplicate fieldnames"));
+    }
+
+    formResource.value.doc.fields.forEach((field: FormField, index: number) => {
+      field.idx = index + 1;
+      if (!field.fieldname || field.fieldname.trim() === "") {
+        field.fieldname = scrubFieldname(field.label);
+      }
+    });
+
+    return formResource.value.setValue.submit(formResource.value.doc, {
+      onSuccess: () => {
+        toast.success("Form Updated Successfully");
+      },
+      onError: (error: any) => {
+        toast.error("Failed to Update Form", {
+          description: error.message,
+        });
+      },
+    });
   }
 
   function saveAndPublish() {

--- a/frontend/src/utils/dialog.ts
+++ b/frontend/src/utils/dialog.ts
@@ -10,6 +10,7 @@ export interface DialogAction {
 export interface DialogOptions {
   title: string;
   message: string;
+  html?: boolean;
   actions?: DialogAction[];
 }
 
@@ -17,6 +18,7 @@ export interface DialogState {
   open: boolean;
   title: string;
   message: string;
+  html: boolean;
   actions: DialogAction[];
   resolve: ((value: boolean) => void) | null;
 }
@@ -25,6 +27,7 @@ export const dialogState = reactive<DialogState>({
   open: false,
   title: "",
   message: "",
+  html: false,
   actions: [],
   resolve: null,
 });
@@ -42,6 +45,7 @@ export const dialog = {
     return new Promise((resolve) => {
       dialogState.title = options.title;
       dialogState.message = options.message;
+      dialogState.html = options.html || false;
       dialogState.actions = options.actions || [
         { label: "OK", variant: "solid" },
       ];

--- a/frontend/src/utils/dialog.ts
+++ b/frontend/src/utils/dialog.ts
@@ -1,0 +1,85 @@
+import { reactive } from "vue";
+
+export interface DialogAction {
+  label: string;
+  variant?: "solid" | "outline" | "ghost" | "subtle";
+  theme?: "red" | "blue" | "green" | "gray";
+  onClick?: () => void | Promise<void>;
+}
+
+export interface DialogOptions {
+  title: string;
+  message: string;
+  actions?: DialogAction[];
+}
+
+export interface DialogState {
+  open: boolean;
+  title: string;
+  message: string;
+  actions: DialogAction[];
+  resolve: ((value: boolean) => void) | null;
+}
+
+export const dialogState = reactive<DialogState>({
+  open: false,
+  title: "",
+  message: "",
+  actions: [],
+  resolve: null,
+});
+
+function closeDialog(result: boolean = false) {
+  dialogState.open = false;
+  if (dialogState.resolve) {
+    dialogState.resolve(result);
+    dialogState.resolve = null;
+  }
+}
+
+export const dialog = {
+  show(options: DialogOptions): Promise<boolean> {
+    return new Promise((resolve) => {
+      dialogState.title = options.title;
+      dialogState.message = options.message;
+      dialogState.actions = options.actions || [
+        { label: "OK", variant: "solid" },
+      ];
+      dialogState.resolve = resolve;
+      dialogState.open = true;
+    });
+  },
+
+  confirm(options: Omit<DialogOptions, "actions">): Promise<boolean> {
+    return this.show({
+      ...options,
+      actions: [
+        {
+          label: "Cancel",
+          variant: "outline",
+          onClick: () => closeDialog(false),
+        },
+        {
+          label: "Confirm",
+          variant: "solid",
+          onClick: () => closeDialog(true),
+        },
+      ],
+    });
+  },
+
+  alert(options: Omit<DialogOptions, "actions">): Promise<boolean> {
+    return this.show({
+      ...options,
+      actions: [
+        {
+          label: "OK",
+          variant: "solid",
+          onClick: () => closeDialog(true),
+        },
+      ],
+    });
+  },
+
+  close: closeDialog,
+};


### PR DESCRIPTION
## Summary
- Add global dialog component for imperative dialogs (like vue-sonner pattern)
- Add HTML support for rich dialog messages
- Detect duplicate fieldnames before save and show user-friendly error with Label(fieldname) pairs

Closes #78

## Test plan
- [ ] Add two fields with the same label
- [ ] Try to save — dialog should appear listing duplicates in bold
- [ ] Change one label and save — should succeed

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a global dialog system to display alerts and confirmations across the application.
  * Form submission now validates fieldname uniqueness and alerts users to duplicates before saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->