### PR TITLE
chore(backport): backport develop features to version-15 (Apr 2026)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
       - version-15
     paths-ignore:
       - ".github/**"
+  merge_group:
 
 concurrency:
   group: version-15-forms_pro-${{ github.event.number }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -7,6 +7,7 @@ on:
       - version-15
     paths-ignore:
       - ".github/**"
+  merge_group:
   workflow_dispatch:
 
 permissions:
@@ -20,7 +21,7 @@ jobs:
   linter:
     name: 'Frappe Linter'
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -14,6 +14,7 @@ on:
     paths:
       - "frontend/**"
       - ".github/workflows/typecheck.yml"
+  merge_group:
 
 concurrency:
   group: typecheck-version-15-forms_pro-${{ github.event.number || github.sha }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -145,7 +145,7 @@ jobs:
 
       - name: Upload HTML report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: frontend/e2e/playwright-report/
@@ -153,7 +153,7 @@ jobs:
 
       - name: Upload failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-results
           path: frontend/e2e/test-results/

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -44,7 +44,7 @@ jobs:
           python-version: "3.14"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           check-latest: true

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ frontend/e2e/playwright-report/
 .playwright-mcp
 
 skills-lock.json
+
+semgrep-rules/

--- a/forms_pro/api/form.py
+++ b/forms_pro/api/form.py
@@ -17,7 +17,7 @@ class FormSharedWithResponse(BaseModel):
     submit: bool
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 def is_login_required(route: str) -> bool:
     """
     Check if login is enabled for a form.
@@ -42,7 +42,7 @@ def get_form_by_route(route: str) -> dict:
     return get_form(form_id)
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 def get_form(form_id: str) -> dict:
     form: Form = frappe.get_doc(
         "Form",
@@ -62,7 +62,7 @@ def get_form(form_id: str) -> dict:
     }
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 def get_link_field_options(
     doctype: str,
     filters: dict | None = None,

--- a/forms_pro/api/settings.py
+++ b/forms_pro/api/settings.py
@@ -2,7 +2,7 @@ import frappe
 from frappe.core.doctype.navbar_settings.navbar_settings import get_app_logo
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 def get_brand_logo() -> str:
     """
     Get the brand logo for the form.
@@ -13,7 +13,7 @@ def get_brand_logo() -> str:
     return str(get_app_logo())
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 def get_website_settings() -> dict:
     website_settings = frappe.get_doc("Website Settings")
     form_settings = {

--- a/forms_pro/api/submission.py
+++ b/forms_pro/api/submission.py
@@ -8,6 +8,7 @@ from frappe.share import add_docshare
 from pydantic import BaseModel, Field, field_validator
 
 from forms_pro.forms_pro.doctype.form.form import Form
+from forms_pro.forms_pro.doctype.form_field.form_field import _DISPLAY_ONLY_FIELDTYPES
 from forms_pro.utils.form_generator import SubmissionStatus
 
 
@@ -85,6 +86,8 @@ def _validate_form_response(form: "Form", form_data: dict) -> None:
     errors: list[str] = []
 
     for field in form.fields:
+        if field.fieldtype in _DISPLAY_ONLY_FIELDTYPES:
+            continue
         is_visible = not field.hidden
         is_required = bool(field.reqd)
 

--- a/forms_pro/forms_pro/doctype/form/form.py
+++ b/forms_pro/forms_pro/doctype/form/form.py
@@ -51,7 +51,7 @@ class Form(Document):
         return users_shared_with
 
     def generate_initial_route(self) -> str:
-        return "s/forms_pro_" + frappe.utils.random_string(8)
+        return "forms_pro_" + frappe.utils.random_string(8)
 
     def before_insert(self) -> None:
         self.status = "Draft"

--- a/forms_pro/forms_pro/doctype/form/test_form.py
+++ b/forms_pro/forms_pro/doctype/form/test_form.py
@@ -41,11 +41,9 @@ class IntegrationTestForm(FrappeTestCase):
         if frappe.db.exists("Form", self.test_form.name):
             self.test_form.delete()
 
-        # Clean up test doctype
+        # Clean up test doctype - delete_doc on DocType triggers DDL which auto-commits
         if frappe.db.exists("DocType", self.test_doctype_name):
             frappe.delete_doc("DocType", self.test_doctype_name, force=True)
-
-        frappe.db.commit()
 
     def create_test_doctype(self):
         """Create a test DocType with some initial fields."""

--- a/forms_pro/forms_pro/doctype/form_field/form_field.json
+++ b/forms_pro/forms_pro/doctype/form_field/form_field.json
@@ -37,7 +37,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Fieldtype",
-   "options": "Attach\nData\nNumber\nEmail\nDate\nDate Time\nDate Range\nTime Picker\nPassword\nSelect\nSwitch\nTextarea\nText Editor\nLink\nCheckbox\nRating\nPhone\nTable\nMultiselect",
+   "options": "Attach\nData\nNumber\nEmail\nDate\nDate Time\nDate Range\nTime Picker\nPassword\nSelect\nSwitch\nTextarea\nText Editor\nLink\nCheckbox\nRating\nPhone\nTable\nMultiselect\nHeading 1\nHeading 2\nHeading 3",
    "reqd": 1
   },
   {
@@ -81,7 +81,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-04-15 16:26:10.519579",
+ "modified": "2026-04-25 20:32:10.994784",
  "modified_by": "Administrator",
  "module": "Forms Pro",
  "name": "Form Field",

--- a/forms_pro/forms_pro/doctype/form_field/form_field.py
+++ b/forms_pro/forms_pro/doctype/form_field/form_field.py
@@ -3,6 +3,7 @@
 
 # import frappe
 from frappe.model.document import Document
+from frappe.utils import escape_html
 
 # Maps Forms Pro field types to Frappe CustomField fieldtypes.
 # When adding a new field type:
@@ -29,7 +30,13 @@ FORM_TO_FRAPPE_FIELDTYPE: dict[str, dict] = {
     "Rating": {"fieldtype": "Rating"},
     "Table": {"fieldtype": "Table"},
     "Multiselect": {"fieldtype": "JSON"},
+    "Heading 1": {"fieldtype": "HTML"},
+    "Heading 2": {"fieldtype": "HTML"},
+    "Heading 3": {"fieldtype": "HTML"},
 }
+
+
+_DISPLAY_ONLY_FIELDTYPES = {"Heading 1", "Heading 2", "Heading 3"}
 
 
 class FormField(Document):
@@ -65,6 +72,9 @@ class FormField(Document):
             "Phone",
             "Table",
             "Multiselect",
+            "Heading 1",
+            "Heading 2",
+            "Heading 3",
         ]
         hidden: DF.Check
         label: DF.Data
@@ -96,13 +106,27 @@ class FormField(Document):
             _fieldtype = "Text"
         elif self.fieldtype == "Multiselect":
             _fieldtype = "JSON"
+        elif self.fieldtype in _DISPLAY_ONLY_FIELDTYPES:
+            _fieldtype = "HTML"
 
         return {
             "fieldname": self.fieldname,
             "fieldtype": _fieldtype,
             "label": self.label,
             "reqd": self.reqd,
-            "options": self.options,
+            "options": self.get_options(),
             "description": self.description,
             "default": self.default,
         }
+
+    def get_options(self) -> str | None:
+        if self.fieldtype in _DISPLAY_ONLY_FIELDTYPES:
+            HEADING_MAP = {
+                "Heading 1": "h1",
+                "Heading 2": "h2",
+                "Heading 3": "h3",
+            }
+            tag = HEADING_MAP.get(self.fieldtype, "h2")
+            return f"<{tag}>{escape_html(self.label or '')}</{tag}>"
+
+        return self.options

--- a/forms_pro/tests/test_form_field.py
+++ b/forms_pro/tests/test_form_field.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2025, harsh@buildwithhussain.com and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from forms_pro.forms_pro.doctype.form_field.form_field import FORM_TO_FRAPPE_FIELDTYPE
+
+
+def _build_field(
+    fieldtype: str, label: str = "Test Field", fieldname: str = "test_field", options: str | None = None
+):
+    """Build an in-memory FormField document without inserting."""
+    doc = frappe.get_doc(
+        {
+            "doctype": "Form Field",
+            "fieldtype": fieldtype,
+            "label": label,
+            "fieldname": fieldname,
+            "options": options,
+        }
+    )
+    return doc
+
+
+class TestFormFieldGetOptions(IntegrationTestCase):
+    def test_heading_1_returns_h1_tag_wrapping_label(self):
+        field = _build_field("Heading 1", label="Introduction")
+        self.assertEqual(field.get_options(), "<h1>Introduction</h1>")
+
+    def test_heading_2_returns_h2_tag_wrapping_label(self):
+        field = _build_field("Heading 2", label="Section A")
+        self.assertEqual(field.get_options(), "<h2>Section A</h2>")
+
+    def test_heading_3_returns_h3_tag_wrapping_label(self):
+        field = _build_field("Heading 3", label="Subsection")
+        self.assertEqual(field.get_options(), "<h3>Subsection</h3>")
+
+    def test_non_heading_returns_options_unchanged(self):
+        field = _build_field("Select", label="Color", options="Red\nBlue\nGreen")
+        self.assertEqual(field.get_options(), "Red\nBlue\nGreen")
+
+    def test_non_heading_with_no_options_returns_none(self):
+        field = _build_field("Data", label="Name")
+        self.assertIsNone(field.get_options())
+
+
+class TestFormFieldToFrappeField(IntegrationTestCase):
+    def test_heading_1_maps_to_html_fieldtype(self):
+        field = _build_field("Heading 1", label="My Heading", fieldname="my_heading")
+        result = field.to_frappe_field
+        self.assertEqual(result["fieldtype"], "HTML")
+
+    def test_heading_2_maps_to_html_fieldtype(self):
+        field = _build_field("Heading 2", label="Sub Heading", fieldname="sub_heading")
+        self.assertEqual(field.to_frappe_field["fieldtype"], "HTML")
+
+    def test_heading_3_maps_to_html_fieldtype(self):
+        field = _build_field("Heading 3", label="Minor Heading", fieldname="minor_heading")
+        self.assertEqual(field.to_frappe_field["fieldtype"], "HTML")
+
+    def test_heading_options_contains_html_tag(self):
+        field = _build_field("Heading 1", label="My Title", fieldname="my_title")
+        result = field.to_frappe_field
+        self.assertIn("<h1>", result["options"])
+        self.assertIn("My Title", result["options"])
+
+    def test_data_field_maps_to_data_frappe_fieldtype(self):
+        field = _build_field("Data", label="Name", fieldname="name_field")
+        self.assertEqual(field.to_frappe_field["fieldtype"], "Data")
+
+    def test_form_to_frappe_fieldtype_has_all_heading_levels(self):
+        for fieldtype in ("Heading 1", "Heading 2", "Heading 3"):
+            with self.subTest(fieldtype=fieldtype):
+                self.assertIn(fieldtype, FORM_TO_FRAPPE_FIELDTYPE)
+                self.assertEqual(FORM_TO_FRAPPE_FIELDTYPE[fieldtype]["fieldtype"], "HTML")

--- a/forms_pro/tests/test_form_field.py
+++ b/forms_pro/tests/test_form_field.py
@@ -2,7 +2,7 @@
 # For license information, please see license.txt
 
 import frappe
-from frappe.tests import IntegrationTestCase
+from frappe.tests.utils import FrappeTestCase as IntegrationTestCase
 
 from forms_pro.forms_pro.doctype.form_field.form_field import FORM_TO_FRAPPE_FIELDTYPE
 

--- a/forms_pro/utils/form_generator.py
+++ b/forms_pro/utils/form_generator.py
@@ -23,7 +23,7 @@ def create_form_with_doctype(team_id: str, doctype: str):
     except Exception as e:
         frappe.log_error(f"Error creating form with doctype: {doctype} - {e}")
         frappe.throw(
-            _("Error creating form with doctype: {0} - {1}").format(doctype, e),
+            _("Error creating form with doctype: {0} - {1}").format(doctype, str(e)),
         )
 
     return {
@@ -47,7 +47,7 @@ def create_form(team_id: str):
     except Exception as e:
         frappe.log_error(f"Error creating form: {e}")
         frappe.throw(
-            _("Error creating form: {0}").format(e),
+            _("Error creating form: {0}").format(str(e)),
         )
 
     return {

--- a/forms_pro/www/forms.py
+++ b/forms_pro/www/forms.py
@@ -10,7 +10,7 @@ CLOSING_SCRIPT_TAG_PATTERN = re.compile(r"</script\>")
 
 def get_context(context):
     csrf_token = frappe.sessions.get_csrf_token()
-    frappe.db.commit()
+    frappe.db.commit()  # nosemgrep: frappe-semgrep-rules.rules.frappe-manual-commit - required to persist CSRF token before page render
     # developer mode
     context.is_developer_mode = frappe.conf.developer_mode
     context.csrf_token = csrf_token

--- a/frontend/e2e/fixtures/test-data.fixture.ts
+++ b/frontend/e2e/fixtures/test-data.fixture.ts
@@ -69,9 +69,9 @@ export const test = base.extend<TestDataFixtures>({
       const formId = message.form_document as string;
       created.push(formId);
 
-      // Publish the form via Frappe REST API
+      // Publish the form via Frappe REST API (also set title to avoid "Untitled Form" transform)
       const publishRes = await apiContext.put(`/api/resource/Form/${formId}`, {
-        data: { is_published: 1 },
+        data: { is_published: 1, title: `E2E Published Form ${Date.now()}` },
       });
       const publishData = await publishRes.json();
       const route = publishData.data?.route as string;

--- a/frontend/e2e/helpers/form-builder.ts
+++ b/frontend/e2e/helpers/form-builder.ts
@@ -3,12 +3,33 @@ import type { Page } from "@playwright/test";
 export class FormBuilderPage {
   constructor(private page: Page) {}
 
-  async goto(formId: string) {
+  async goto(
+    formId: string,
+    options?: { title?: string; skipTitleFill?: boolean }
+  ) {
     await this.page.goto(`/forms/edit-form/${formId}`);
     // Wait for the sidebar to confirm the builder is mounted
     await this.page.waitForSelector(
       '[data-form-builder-component="form-builder-sidebar"]'
     );
+
+    if (options?.skipTitleFill) return;
+
+    // Set unique title to avoid MandatoryError on save (frontend transforms "Untitled Form" → "")
+    const title = options?.title ?? `E2E Form ${Date.now()}`;
+    await this.page.getByPlaceholder("Untitled Form").fill(title);
+
+    // Save immediately so form is clean and Publish/Unpublish button shows
+    const saveBtn = this.page.getByRole("button", {
+      name: "Save",
+      exact: true,
+    });
+    // Wait briefly for dirty state to propagate
+    await this.page.waitForTimeout(200);
+    if (await saveBtn.isVisible()) {
+      await saveBtn.click();
+      await saveBtn.waitFor({ state: "hidden", timeout: 30000 });
+    }
   }
 
   // Scope selectors to the sidebar (which has a stable pre-existing attribute)

--- a/frontend/e2e/specs/form-creation.spec.ts
+++ b/frontend/e2e/specs/form-creation.spec.ts
@@ -58,7 +58,8 @@ test.describe("Form Creation", () => {
   }) => {
     const { formId } = await createPublishedForm();
     const builder = new FormBuilderPage(page);
-    await builder.goto(formId);
+    // skipTitleFill: createPublishedForm already set title, don't make form dirty
+    await builder.goto(formId, { skipTitleFill: true });
 
     // Published form → Unpublish button visible
     await expect(

--- a/frontend/e2e/specs/heading-field.spec.ts
+++ b/frontend/e2e/specs/heading-field.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from "../fixtures/test-data.fixture";
+import { FormBuilderPage } from "../helpers/form-builder";
+import { SubmissionPage } from "../helpers/submission";
+
+test.describe("Heading fields", () => {
+  test("all three heading types appear in the Add Fields sidebar", async ({
+    page,
+    createForm,
+  }) => {
+    const formId = await createForm();
+    const builder = new FormBuilderPage(page);
+    await builder.goto(formId);
+
+    const sidebar = page.locator(
+      '[data-form-builder-component="form-builder-sidebar"]'
+    );
+    await expect(sidebar.getByText("Heading 1", { exact: true })).toBeVisible();
+    await expect(sidebar.getByText("Heading 2", { exact: true })).toBeVisible();
+    await expect(sidebar.getByText("Heading 3", { exact: true })).toBeVisible();
+  });
+
+  test("adding Heading 1 shows editable input in builder (edit mode)", async ({
+    page,
+    createForm,
+  }) => {
+    const formId = await createForm();
+    const builder = new FormBuilderPage(page);
+    await builder.goto(formId);
+
+    await builder.addField("Heading 1");
+
+    // In edit mode (field selected), shows input with placeholder
+    const headingInput = page.getByPlaceholder("Heading Text").first();
+    await expect(headingInput).toBeVisible({ timeout: 5000 });
+  });
+
+  test("heading label is editable in builder", async ({ page, createForm }) => {
+    const formId = await createForm();
+    const builder = new FormBuilderPage(page);
+    await builder.goto(formId);
+
+    await builder.addField("Heading 1");
+
+    // Edit mode shows a text input for the heading label
+    const headingInput = page.getByPlaceholder("Heading Text").first();
+    await expect(headingInput).toBeVisible({ timeout: 5000 });
+    await headingInput.fill("About You");
+
+    // Verify the input has the value we typed
+    await expect(headingInput).toHaveValue("About You");
+  });
+
+  test("heading renders on the public submission page without an input", async ({
+    page,
+    browser,
+    createForm,
+    apiContext,
+  }) => {
+    const formId = await createForm();
+    const builder = new FormBuilderPage(page);
+    await builder.goto(formId);
+
+    await builder.addField("Heading 2");
+    const headingInput = page.getByPlaceholder("Heading Text").first();
+    await expect(headingInput).toBeVisible({ timeout: 5000 });
+    await headingInput.fill("Your Details");
+
+    await builder.publish();
+
+    const res = await apiContext.get(`/api/resource/Form/${formId}`);
+    const { data } = await res.json();
+    const route: string = data.route;
+
+    const guestCtx = await browser.newContext();
+    const guestPage = await guestCtx.newPage();
+    const submissionPage = new SubmissionPage(guestPage);
+    await submissionPage.goto(route);
+
+    // Heading renders as text, not as an input
+    await expect(
+      guestPage.locator("h3", { hasText: "Your Details" })
+    ).toBeVisible({
+      timeout: 10000,
+    });
+    // h3 because Heading 2 → h3 tag in Heading.vue
+
+    await guestCtx.close();
+  });
+
+  test("form with heading fields submits successfully", async ({
+    browser,
+    createPublishedForm,
+    apiContext,
+  }) => {
+    const { formId, route } = await createPublishedForm();
+
+    // Add a Heading 1 field to the published form via REST
+    const formRes = await apiContext.get(`/api/resource/Form/${formId}`);
+    const { data: formData } = await formRes.json();
+
+    await apiContext.put(`/api/resource/Form/${formId}`, {
+      data: {
+        fields: [
+          ...(formData.fields ?? []),
+          {
+            fieldtype: "Heading 1",
+            label: "Section Header",
+            fieldname: "section_header",
+            reqd: 0,
+          },
+        ],
+      },
+    });
+
+    // Guest submits — heading must not cause a server-side validation error
+    const guestCtx = await browser.newContext();
+    const guestPage = await guestCtx.newPage();
+    const submissionPage = new SubmissionPage(guestPage);
+    await submissionPage.goto(route);
+
+    await expect(guestPage.getByRole("button", { name: "Submit" })).toBeVisible(
+      {
+        timeout: 10000,
+      }
+    );
+    await submissionPage.submit();
+
+    await expect(submissionPage.successMessage()).toBeVisible({
+      timeout: 10000,
+    });
+
+    await guestCtx.close();
+  });
+});

--- a/frontend/e2e/specs/multiselect-field.spec.ts
+++ b/frontend/e2e/specs/multiselect-field.spec.ts
@@ -13,9 +13,6 @@ test.describe("Multiselect field", () => {
     const builder = new FormBuilderPage(page);
     await builder.goto(formId);
 
-    // Set a form title so Save doesn't fail with MandatoryError (title is required)
-    await page.getByPlaceholder("Untitled Form").fill("Multiselect Test Form");
-
     // Add Multiselect field from sidebar; wait for canvas extras to confirm render
     await builder.addField("Multiselect");
     await expect(page.getByRole("button", { name: "Add Option" })).toBeVisible({

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "test:e2e:debug": "playwright test --debug"
   },
   "dependencies": {
-    "@lottiefiles/dotlottie-vue": "^0.10.4",
+    "@lottiefiles/dotlottie-vue": "^0.11.11",
     "@vueuse/core": "^13.9.0",
     "dayjs": "^1.11.20",
     "feather-icons": "^4.29.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@lottiefiles/dotlottie-vue": "^0.10.4",
     "@vueuse/core": "^13.9.0",
-    "dayjs": "^1.11.19",
+    "dayjs": "^1.11.20",
     "feather-icons": "^4.29.2",
     "frappe-ui": "^0.1.272",
     "lucide-vue-next": "^0.575.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,7 +34,7 @@
     "@biomejs/biome": "1.9.4",
     "@playwright/test": "^1.59.1",
     "@types/node": "^25.6.0",
-    "@vitejs/plugin-vue": "^6.0.5",
+    "@vitejs/plugin-vue": "^6.0.6",
     "@vitest/coverage-v8": "^4.1.4",
     "autoprefixer": "^10.4.2",
     "jsdom": "^29.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "lucide-vue-next": "^0.575.0",
     "pinia": "^3.0.3",
     "socket.io-client": "^4.8.3",
-    "vue": "^3.5.32",
+    "vue": "^3.5.33",
     "vue-advanced-cropper": "^2.6.2",
     "vue-router": "^4.5.0",
     "vue-sonner": "^2.0.9",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     "@vitest/coverage-v8": "^4.1.4",
     "autoprefixer": "^10.4.2",
     "jsdom": "^29.0.2",
-    "postcss": "^8.5.8",
+    "postcss": "^8.5.10",
     "tailwindcss": "^3.4.15",
     "typescript": "^5.9.3",
     "vite": "^8.0.8",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import "vue-sonner/style.css";
 import { Toaster } from "vue-sonner";
+import GlobalDialog from "@/components/ui/GlobalDialog.vue";
 import { useUser } from "@/stores/user";
 
 const userStore = useUser();
@@ -12,4 +13,5 @@ userStore.initialize();
         <router-view />
     </div>
     <Toaster theme="system" />
+    <GlobalDialog />
 </template>

--- a/frontend/src/components/FormBuilderContent.vue
+++ b/frontend/src/components/FormBuilderContent.vue
@@ -1,18 +1,19 @@
 <script setup lang="ts">
 import draggableComponent from "vuedraggable";
-import { LoadingIndicator, TextEditor, Button } from "frappe-ui";
+import { LoadingIndicator, TextEditor } from "frappe-ui";
 import { useEditForm } from "@/stores/editForm";
-import { GripVertical } from "lucide-vue-next";
 import { FormField } from "@/types/formfield";
 import { ref } from "vue";
 import { onClickOutside } from "@vueuse/core";
 
 import FieldRenderer from "@/components/builder/FieldRenderer.vue";
+import FieldActions from "@/components/builder/FieldActions.vue";
 
 const editFormStore = useEditForm();
 
 // Ref for the entire FormBuilderContent component
 const fieldContentRef = ref<HTMLElement | null>(null);
+const isDraggingField = ref(false);
 
 // Function to check if an element is a dropdown/popover (including portals)
 const isDropdownOrPopover = (element: Element | null): boolean => {
@@ -145,14 +146,24 @@ onClickOutside(fieldContentRef, (event) => {
             </div>
         </div>
         <div>
-            <draggableComponent :list="editFormStore.fields" item-key="idx" tag="div">
+            <draggableComponent
+                :list="editFormStore.fields"
+                item-key="idx"
+                tag="div"
+                handle=".handle"
+                @start="isDraggingField = true"
+                @end="isDraggingField = false"
+            >
                 <template #item="{ element }">
                     <div
                         @click="editFormStore.selectField(element)"
-                        :class="{ 'border-gray-400': editFormStore.selectedField === element }"
-                        class="p-2 my-3 bg-gray-50 rounded border flex gap-2 relative transition-colors"
+                        class="my-3 relative transition-colors group"
                     >
-                        <GripVertical class="w-4 h-4 handle" />
+                        <FieldActions
+                            :isSelected="editFormStore.selectedField === element"
+                            :isDraggingAnyField="isDraggingField"
+                            @remove="editFormStore.removeField(element)"
+                        />
                         <FieldRenderer
                             :field="element"
                             @update:field="
@@ -161,21 +172,9 @@ onClickOutside(fieldContentRef, (event) => {
                             "
                             :inEditMode="true"
                         />
-                        <Button
-                            icon="x"
-                            variant="outline"
-                            class="absolute -top-2 -right-2"
-                            @click="editFormStore.removeField(element)"
-                        />
                     </div>
                 </template>
             </draggableComponent>
         </div>
     </div>
 </template>
-
-<style scoped>
-.handle {
-    cursor: grab;
-}
-</style>

--- a/frontend/src/components/RenderField.vue
+++ b/frontend/src/components/RenderField.vue
@@ -16,6 +16,10 @@ const props = defineProps({
         required: false,
         default: undefined,
     },
+    inEditMode: {
+        type: Boolean,
+        default: false,
+    },
 });
 
 const value = defineModel();
@@ -35,6 +39,7 @@ const getComponent = computed(() => {
         :is="getComponent.component"
         :field="props.field"
         :options="resolvedOptions"
+        :in-edit-mode="props.inEditMode"
         v-bind="getComponent.props"
     />
 </template>

--- a/frontend/src/components/builder/FieldActions.vue
+++ b/frontend/src/components/builder/FieldActions.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { GripVertical, Trash2 } from "@lucide/vue";
+import { GripVertical, Trash2 } from "lucide-vue-next";
 import { Button } from "frappe-ui";
 
 defineProps<{

--- a/frontend/src/components/builder/FieldActions.vue
+++ b/frontend/src/components/builder/FieldActions.vue
@@ -22,8 +22,20 @@ defineEmits<{
                 : 'opacity-0 scale-90 group-hover:opacity-100 group-hover:scale-100',
         ]"
     >
-        <Button size="sm" :icon="Trash2" variant="ghost" @click.stop="$emit('remove')" />
-        <Button class="handle" size="sm" :icon="GripVertical" variant="ghost" />
+        <Button
+            size="sm"
+            :icon="Trash2"
+            variant="ghost"
+            @click.stop="$emit('remove')"
+            tooltip="Remove this field"
+        />
+        <Button
+            class="handle"
+            size="sm"
+            :icon="GripVertical"
+            variant="ghost"
+            tooltip="Drag to move"
+        />
     </div>
 </template>
 

--- a/frontend/src/components/builder/FieldActions.vue
+++ b/frontend/src/components/builder/FieldActions.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { GripVertical, Trash2 } from "@lucide/vue";
+import { Button } from "frappe-ui";
+
+defineProps<{
+    isSelected: boolean;
+    isDraggingAnyField: boolean;
+}>();
+
+defineEmits<{
+    (e: "remove"): void;
+}>();
+</script>
+<template>
+    <div
+        :class="[
+            'absolute right-full top-2 mr-2 flex flex-row items-center rounded border bg-surface-white px-1 h-8 transition-all duration-200 ease-out ',
+            isSelected
+                ? 'opacity-100 scale-100'
+                : isDraggingAnyField
+                ? 'opacity-0 scale-90 pointer-events-none'
+                : 'opacity-0 scale-90 group-hover:opacity-100 group-hover:scale-100',
+        ]"
+    >
+        <Button size="sm" :icon="Trash2" variant="ghost" @click.stop="$emit('remove')" />
+        <Button class="handle" size="sm" :icon="GripVertical" variant="ghost" />
+    </div>
+</template>
+
+<style scoped>
+.handle {
+    cursor: grab;
+}
+
+.handle:active {
+    cursor: grabbing;
+}
+</style>

--- a/frontend/src/components/builder/FieldRenderer.vue
+++ b/frontend/src/components/builder/FieldRenderer.vue
@@ -2,6 +2,7 @@
 import { computed } from "vue";
 import { Asterisk } from "lucide-vue-next";
 import RenderField from "../RenderField.vue";
+import Heading from "@/components/fields/Heading.vue";
 import Table from "@/components/fields/Table.vue";
 import { useFieldOptions } from "@/utils/selectOptions";
 import { getFieldTypeDef, type Fieldtype } from "@/config/fieldTypes";
@@ -175,6 +176,17 @@ const { options: selectOptions } = useFieldOptions(fieldData);
                 v-model="modelValue as undefined"
                 :in-edit-mode="inEditMode"
                 :doctype="fieldData.options"
+            />
+        </div>
+        <!-- heading: renders field label as h1/h2/h3; no input -->
+        <div
+            v-else-if="['Heading 1', 'Heading 2', 'Heading 3'].includes(fieldData.fieldtype)"
+            class="w-full py-1"
+        >
+            <Heading
+                :field="fieldData"
+                :in-edit-mode="inEditMode"
+                @update:label="fieldData.label = $event"
             />
         </div>
         <div v-else :class="getClasses">

--- a/frontend/src/components/builder/FieldRenderer.vue
+++ b/frontend/src/components/builder/FieldRenderer.vue
@@ -148,6 +148,7 @@ const { options: selectOptions } = useFieldOptions(fieldData);
                 :value="modelValue"
                 @update:value="(value: string) => (modelValue = value)"
                 :field="fieldData"
+                :in-edit-mode="inEditMode"
                 :class="{ 'pointer-events-none': inEditMode }"
                 :disabled="disabled"
             />

--- a/frontend/src/components/fields/Heading.vue
+++ b/frontend/src/components/fields/Heading.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { Fieldtype } from "@/types/FormsPro/form_field.types";
+import { computed } from "vue";
+
+const props = defineProps<{
+    field: {
+        label?: string;
+        fieldtype?: Fieldtype;
+    };
+    inEditMode: boolean;
+}>();
+
+const emit = defineEmits<{
+    "update:label": [value: string];
+}>();
+
+const headingClasses: Record<HeadingFieldtype, string> = {
+    [Fieldtype.HEADING_1]: "text-xl font-bold",
+    [Fieldtype.HEADING_2]: "text-lg font-semibold",
+    [Fieldtype.HEADING_3]: "text-base font-semibold",
+};
+
+type HeadingFieldtype = Fieldtype.HEADING_1 | Fieldtype.HEADING_2 | Fieldtype.HEADING_3;
+type HeadingTag = "h2" | "h3" | "h4";
+
+const headingTypeToTag: Record<HeadingFieldtype, HeadingTag> = {
+    [Fieldtype.HEADING_1]: "h2",
+    [Fieldtype.HEADING_2]: "h3",
+    [Fieldtype.HEADING_3]: "h4",
+};
+
+const headingTag = computed<HeadingTag>(
+    () => headingTypeToTag[props.field.fieldtype as HeadingFieldtype] ?? "h2"
+);
+
+const headingClass = computed(
+    () => headingClasses[props.field.fieldtype as HeadingFieldtype] ?? ""
+);
+</script>
+
+<template>
+    <input
+        v-if="inEditMode"
+        type="text"
+        :value="field.label"
+        @input="emit('update:label', ($event.target as HTMLInputElement).value)"
+        :class="[
+            headingClass,
+            'bg-transparent border-none outline-none text-base focus:ring-0 w-full px-0 py-2 text-balance',
+        ]"
+        placeholder="Heading Text"
+        aria-label="Heading text"
+    />
+    <component v-else :is="headingTag" :class="[headingClass, 'text-balance']">
+        {{ field.label }}
+    </component>
+</template>

--- a/frontend/src/components/fields/multiselect/Multiselect.vue
+++ b/frontend/src/components/fields/multiselect/Multiselect.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import { Checkbox } from "frappe-ui";
+import { Button, Checkbox } from "frappe-ui";
 
 const props = defineProps<{
     options?: string[];
     disabled?: boolean;
+    inEditMode?: boolean;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    field?: Record<string, any>;
 }>();
 
 const modelValue = defineModel<string[]>({ default: () => [] });
@@ -25,24 +28,46 @@ function toggle(option: string, checked: boolean) {
         selected.value = selected.value.filter((v) => v !== option);
     }
 }
+
+function removeOption(option: string) {
+    if (!props.field) return;
+    const items = (props.field.options ?? "").split("\n").filter(Boolean);
+    props.field.options = items.filter((v: string) => v !== option).join("\n");
+    selected.value = selected.value.filter((v) => v !== option);
+}
 </script>
 
 <template>
     <div class="flex flex-col gap-1">
-        <label
+        <div
             v-for="option in options"
             :key="option"
-            class="flex items-center gap-2 min-h-[32px] rounded px-1 cursor-pointer hover:bg-surface-gray-2 active:bg-surface-gray-3 transition"
-            :class="{ 'opacity-50 cursor-not-allowed': disabled }"
+            class="flex items-center gap-2 min-h-[32px] rounded px-1 transition"
+            :class="[
+                inEditMode
+                    ? 'hover:bg-surface-gray-2'
+                    : 'cursor-pointer hover:bg-surface-gray-2 active:bg-surface-gray-3',
+                { 'opacity-50 cursor-not-allowed': disabled },
+            ]"
         >
-            <Checkbox
-                :modelValue="selected.includes(option)"
-                :disabled="disabled"
+            <label class="flex items-center gap-2 flex-1">
+                <Checkbox
+                    :modelValue="selected.includes(option)"
+                    :disabled="disabled"
+                    size="sm"
+                    @update:modelValue="toggle(option, $event)"
+                />
+                <span class="text-base text-ink-gray-8 select-none">{{ option }}</span>
+            </label>
+            <Button
+                v-if="inEditMode"
+                variant="ghost"
+                icon="x"
                 size="sm"
-                @update:modelValue="toggle(option, $event)"
+                class="!size-5 pointer-events-auto"
+                @click.stop="removeOption(option)"
             />
-            <span class="text-base text-ink-gray-8 select-none">{{ option }}</span>
-        </label>
+        </div>
         <span v-if="!options?.length" class="text-sm text-ink-gray-4 italic">
             No options defined
         </span>

--- a/frontend/src/components/fields/multiselect/MultiselectBuilderExtras.vue
+++ b/frontend/src/components/fields/multiselect/MultiselectBuilderExtras.vue
@@ -11,6 +11,8 @@ const newOptionValue = ref("");
 const newOptionInput = ref<InstanceType<typeof FormControl> | null>(null);
 
 async function startAddingOption() {
+    newOptionValue.value = "";
+    errorMessage.value = "";
     isAddingOption.value = true;
     await nextTick();
     newOptionInput.value?.$el?.querySelector("input")?.focus();

--- a/frontend/src/components/form/submissions/SubmissionFieldValue.vue
+++ b/frontend/src/components/form/submissions/SubmissionFieldValue.vue
@@ -78,7 +78,7 @@ const classNames = computed<string>(() =>
 
 <template>
     <div :class="classNames">
-        <div v-if="!isHeading(fieldtype)">
+        <div v-if="!isHeading(fieldtype as unknown as Fieldtype)">
             <span class="text-sm text-ink-gray-5">{{ label }}</span>
             <p v-if="description" class="text-xs text-ink-gray-4">{{ description }}</p>
         </div>
@@ -132,8 +132,8 @@ const classNames = computed<string>(() =>
         </span>
 
         <Heading
-            v-else-if="isHeading(fieldtype)"
-            :field="{ label, fieldtype }"
+            v-else-if="isHeading(fieldtype as unknown as Fieldtype)"
+            :field="{ label, fieldtype: fieldtype as unknown as Fieldtype }"
             :in-edit-mode="false"
         />
 

--- a/frontend/src/components/form/submissions/SubmissionFieldValue.vue
+++ b/frontend/src/components/form/submissions/SubmissionFieldValue.vue
@@ -5,6 +5,8 @@ import { getFieldTypeDef } from "@/config/fieldTypes";
 import { Fieldtype } from "@/types/FormsPro/form_field.types";
 import { formatDate, formatDateTime, formatTime } from "@/utils/date";
 import { computed } from "vue";
+import { isHeading } from "@/utils/form_fields";
+import Heading from "@/components/fields/Heading.vue";
 
 const props = defineProps<{
     fieldname: string;
@@ -76,7 +78,7 @@ const classNames = computed<string>(() =>
 
 <template>
     <div :class="classNames">
-        <div>
+        <div v-if="!isHeading(fieldtype)">
             <span class="text-sm text-ink-gray-5">{{ label }}</span>
             <p v-if="description" class="text-xs text-ink-gray-4">{{ description }}</p>
         </div>
@@ -128,6 +130,12 @@ const classNames = computed<string>(() =>
         <span v-else-if="isDateField" class="text-sm text-ink-gray-7">
             {{ formattedDateValue }}
         </span>
+
+        <Heading
+            v-else-if="isHeading(fieldtype)"
+            :field="{ label, fieldtype }"
+            :in-edit-mode="false"
+        />
 
         <span v-else class="text-sm text-ink-gray-7">
             {{ value ?? "–" }}

--- a/frontend/src/components/ui/GlobalDialog.vue
+++ b/frontend/src/components/ui/GlobalDialog.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { Dialog } from "frappe-ui";
+import { dialogState } from "@/utils/dialog";
+</script>
+
+<template>
+    <Dialog
+        v-model="dialogState.open"
+        :options="{
+            title: dialogState.title,
+            actions: dialogState.actions,
+        }"
+    >
+        <template #body-content>
+            <p
+                v-if="dialogState.html"
+                class="text-p-base text-gray-700"
+                v-html="dialogState.message"
+            ></p>
+            <p v-else class="text-p-base text-gray-700">
+                {{ dialogState.message }}
+            </p>
+        </template>
+    </Dialog>
+</template>

--- a/frontend/src/config/fieldTypes.ts
+++ b/frontend/src/config/fieldTypes.ts
@@ -34,6 +34,7 @@ import {
   FormControl,
 } from "frappe-ui";
 import Attachment from "@/components/fields/Attachment.vue";
+import Heading from "@/components/fields/Heading.vue";
 import Multiselect from "@/components/fields/multiselect/Multiselect.vue";
 import MultiselectBuilderExtras from "@/components/fields/multiselect/MultiselectBuilderExtras.vue";
 import Phone from "@/components/fields/Phone.vue";
@@ -50,7 +51,12 @@ export { Fieldtype };
  * - "description-first" label on top, description below label, input at the bottom (Text Editor)
  * - "custom"            the component handles its own full layout (Table)
  */
-export type FieldLayout = "default" | "inline" | "description-first" | "custom";
+export type FieldLayout =
+  | "default"
+  | "inline"
+  | "description-first"
+  | "custom"
+  | "heading";
 
 export type FieldTypeDefinition = {
   /** Canonical name — must match a Fieldtype enum value */
@@ -270,6 +276,33 @@ export const FIELD_TYPE_DEFINITIONS: FieldTypeDefinition[] = [
     isBoolean: false,
     isDate: false,
     builderExtras: MultiselectBuilderExtras,
+  },
+  {
+    name: Fieldtype.HEADING_1,
+    component: Heading,
+    props: {},
+    layout: "heading",
+    frappeFieldtype: "HTML",
+    isBoolean: false,
+    isDate: false,
+  },
+  {
+    name: Fieldtype.HEADING_2,
+    component: Heading,
+    props: {},
+    layout: "heading",
+    frappeFieldtype: "HTML",
+    isBoolean: false,
+    isDate: false,
+  },
+  {
+    name: Fieldtype.HEADING_3,
+    component: Heading,
+    props: {},
+    layout: "heading",
+    frappeFieldtype: "HTML",
+    isBoolean: false,
+    isDate: false,
   },
 ];
 

--- a/frontend/src/stores/editForm.ts
+++ b/frontend/src/stores/editForm.ts
@@ -5,6 +5,7 @@ import { mapDoctypeFieldForForm } from "@/utils/form_fields";
 import { FormField, FormFieldTypes } from "@/types/formfield";
 import { Form } from "@/types/form";
 import { toast } from "vue-sonner";
+import { dialog } from "@/utils/dialog";
 
 function scrubFieldname(label: string) {
   return label
@@ -90,30 +91,65 @@ export const useEditForm = defineStore("editForm", () => {
     formResource.value = null;
   }
 
-  function save() {
-    if (formResource.value) {
-      formResource.value.doc.fields.forEach(
-        (field: FormField, index: number) => {
-          field.idx = index + 1;
-          if (!field.fieldname || field.fieldname.trim() === "") {
-            field.fieldname = scrubFieldname(field.label);
-          }
-        }
-      );
+  function findDuplicateFieldnames(): { label: string; fieldname: string }[] {
+    const allFields = formResource.value?.doc?.fields || [];
+    const seen = new Map<string, FormField>();
+    const duplicates: { label: string; fieldname: string }[] = [];
 
-      return formResource.value.setValue.submit(formResource.value.doc, {
-        onSuccess: () => {
-          toast.success("Form Updated Successfully");
-        },
-        onError: (error: any) => {
-          toast.error("Failed to Update Form", {
-            description: error.message,
-          });
-        },
-      });
+    for (const field of allFields) {
+      const name = field.fieldname?.trim()
+        ? field.fieldname
+        : scrubFieldname(field.label);
+
+      if (seen.has(name)) {
+        const existing = seen.get(name)!;
+        if (!duplicates.some((d) => d.fieldname === name)) {
+          duplicates.push({ label: existing.label, fieldname: name });
+        }
+        duplicates.push({ label: field.label, fieldname: name });
+      }
+      seen.set(name, field);
     }
-    toast.error("No form resource available");
-    return Promise.reject(new Error("No form resource available"));
+
+    return duplicates;
+  }
+
+  async function save() {
+    if (!formResource.value) {
+      toast.error("No form resource available");
+      return Promise.reject(new Error("No form resource available"));
+    }
+
+    const duplicates = findDuplicateFieldnames();
+    if (duplicates.length > 0) {
+      const fieldList = duplicates
+        .map((d) => `<b>${d.label} (${d.fieldname})</b>`)
+        .join(", ");
+      await dialog.alert({
+        title: "Duplicate Fieldnames",
+        message: `These fields will have duplicate fieldnames: ${fieldList}. Please change one of the labels or set a unique fieldname.`,
+        html: true,
+      });
+      return Promise.reject(new Error("Duplicate fieldnames"));
+    }
+
+    formResource.value.doc.fields.forEach((field: FormField, index: number) => {
+      field.idx = index + 1;
+      if (!field.fieldname || field.fieldname.trim() === "") {
+        field.fieldname = scrubFieldname(field.label);
+      }
+    });
+
+    return formResource.value.setValue.submit(formResource.value.doc, {
+      onSuccess: () => {
+        toast.success("Form Updated Successfully");
+      },
+      onError: (error: any) => {
+        toast.error("Failed to Update Form", {
+          description: error.message,
+        });
+      },
+    });
   }
 
   function saveAndPublish() {

--- a/frontend/src/types/FormsPro/form_field.types.ts
+++ b/frontend/src/types/FormsPro/form_field.types.ts
@@ -18,6 +18,9 @@ export enum Fieldtype {
   "PHONE" = "Phone",
   "TABLE" = "Table",
   "MULTISELECT" = "Multiselect",
+  "HEADING_1" = "Heading 1",
+  "HEADING_2" = "Heading 2",
+  "HEADING_3" = "Heading 3",
 }
 
 export interface FormField {

--- a/frontend/src/utils/dialog.ts
+++ b/frontend/src/utils/dialog.ts
@@ -1,0 +1,89 @@
+import { reactive } from "vue";
+
+export interface DialogAction {
+  label: string;
+  variant?: "solid" | "outline" | "ghost" | "subtle";
+  theme?: "red" | "blue" | "green" | "gray";
+  onClick?: () => void | Promise<void>;
+}
+
+export interface DialogOptions {
+  title: string;
+  message: string;
+  html?: boolean;
+  actions?: DialogAction[];
+}
+
+export interface DialogState {
+  open: boolean;
+  title: string;
+  message: string;
+  html: boolean;
+  actions: DialogAction[];
+  resolve: ((value: boolean) => void) | null;
+}
+
+export const dialogState = reactive<DialogState>({
+  open: false,
+  title: "",
+  message: "",
+  html: false,
+  actions: [],
+  resolve: null,
+});
+
+function closeDialog(result: boolean = false) {
+  dialogState.open = false;
+  if (dialogState.resolve) {
+    dialogState.resolve(result);
+    dialogState.resolve = null;
+  }
+}
+
+export const dialog = {
+  show(options: DialogOptions): Promise<boolean> {
+    return new Promise((resolve) => {
+      dialogState.title = options.title;
+      dialogState.message = options.message;
+      dialogState.html = options.html || false;
+      dialogState.actions = options.actions || [
+        { label: "OK", variant: "solid" },
+      ];
+      dialogState.resolve = resolve;
+      dialogState.open = true;
+    });
+  },
+
+  confirm(options: Omit<DialogOptions, "actions">): Promise<boolean> {
+    return this.show({
+      ...options,
+      actions: [
+        {
+          label: "Cancel",
+          variant: "outline",
+          onClick: () => closeDialog(false),
+        },
+        {
+          label: "Confirm",
+          variant: "solid",
+          onClick: () => closeDialog(true),
+        },
+      ],
+    });
+  },
+
+  alert(options: Omit<DialogOptions, "actions">): Promise<boolean> {
+    return this.show({
+      ...options,
+      actions: [
+        {
+          label: "OK",
+          variant: "solid",
+          onClick: () => closeDialog(true),
+        },
+      ],
+    });
+  },
+
+  close: closeDialog,
+};

--- a/frontend/src/utils/form_fields.ts
+++ b/frontend/src/utils/form_fields.ts
@@ -55,3 +55,11 @@ export const mapDoctypeFieldForForm = (
 
   return FRAPPE_TO_FORM_TYPE[fieldtype];
 };
+
+export const isHeading = (fieldtype: Fieldtype): boolean => {
+  return [
+    Fieldtype.HEADING_1,
+    Fieldtype.HEADING_2,
+    Fieldtype.HEADING_3,
+  ].includes(fieldtype);
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2574,10 +2574,10 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.4.47, postcss@^8.5.8:
-  version "8.5.8"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.8.tgz#6230ecc8fb02e7a0f6982e53990937857e13f399"
-  integrity sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==
+postcss@^8.4.47, postcss@^8.5.10, postcss@^8.5.8:
+  version "8.5.10"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.10.tgz#8992d8c30acf3f12169e7c09514a12fed7e48356"
+  integrity sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==
   dependencies:
     nanoid "^3.3.11"
     picocolors "^1.1.1"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -490,15 +490,15 @@
   resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz#cef11bc89149f3a77771727be75490fbb13ae193"
   integrity sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==
 
+"@rolldown/pluginutils@1.0.0-rc.13":
+  version "1.0.0-rc.13"
+  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz#093a01af0cde13552f058544fcadf12e9b522c3b"
+  integrity sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==
+
 "@rolldown/pluginutils@1.0.0-rc.15":
   version "1.0.0-rc.15"
   resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz#e75d7731593e195d23710f9ff49bf5c745c96682"
   integrity sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==
-
-"@rolldown/pluginutils@1.0.0-rc.2":
-  version "1.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.2.tgz#10324e74cb3396cb7b616042ea7e9e6aa7d8d458"
-  integrity sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==
 
 "@socket.io/component-emitter@~3.1.0":
   version "3.1.2"
@@ -903,12 +903,12 @@
   resolved "https://registry.yarnpkg.com/@vexip-ui/utils/-/utils-2.16.4.tgz#3429376a8f9e88040e969c21f14e70fe25d36127"
   integrity sha512-KX+Q4EsuwDp6ZlRJ7OAkiYxu52D5CVM8zpqQz/FXYV+JUtzl9T3dvxgtA8gQ0wm5Sh/xT6jp8Wo4X7tLAzRh/A==
 
-"@vitejs/plugin-vue@^6.0.5":
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-6.0.5.tgz#20ebb46c4da069753d9cfb1309c4334213cc3f7b"
-  integrity sha512-bL3AxKuQySfk1iGcBsQnoRVexTPJq0Z/ixFVM8OhVJAP6ZXXXLtM7NFKWhLl30Kg7uTBqIaPXbh+nuQCuBDedg==
+"@vitejs/plugin-vue@^6.0.6":
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-6.0.6.tgz#4d8a3a7941382cf2760ac5593364bea6856ae7b2"
+  integrity sha512-u9HHgfrq3AjXlysn0eINFnWQOJQLO9WN6VprZ8FXl7A2bYisv3Hui9Ij+7QZ41F/WYWarHjwBbXtD7dKg3uxbg==
   dependencies:
-    "@rolldown/pluginutils" "1.0.0-rc.2"
+    "@rolldown/pluginutils" "1.0.0-rc.13"
 
 "@vitest/coverage-v8@^4.1.4":
   version "4.1.4"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -344,17 +344,17 @@
   resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.4.0.tgz#08d6c5e20cf7e4cc02fd181c4b0c225cd31dbb60"
   integrity sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==
 
-"@lottiefiles/dotlottie-vue@^0.10.4":
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/@lottiefiles/dotlottie-vue/-/dotlottie-vue-0.10.4.tgz#0f7b905daae148b8a0b741caef6acd40a0ab8bcd"
-  integrity sha512-3A2JKV9wtpWVF5IIl/vFZIoWoe7qey+tQq7v76H+yjhGhAkHIpQHlpDWGJ7AD6TjQymjQHgZfyzPiLxTcd5HVQ==
+"@lottiefiles/dotlottie-vue@^0.11.11":
+  version "0.11.11"
+  resolved "https://registry.yarnpkg.com/@lottiefiles/dotlottie-vue/-/dotlottie-vue-0.11.11.tgz#cd3e80e32f9d698f5d7853240e807929aa5bdeda"
+  integrity sha512-rYjN1PdDVyy8iMbKIqBTKNfg7DoFu/MrG9ARuSjqGIf/daNEIpygOVwfrcN21TFatDvDc7MxFvWu8OBTzGVwNw==
   dependencies:
-    "@lottiefiles/dotlottie-web" "0.54.0"
+    "@lottiefiles/dotlottie-web" "0.71.0"
 
-"@lottiefiles/dotlottie-web@0.54.0":
-  version "0.54.0"
-  resolved "https://registry.yarnpkg.com/@lottiefiles/dotlottie-web/-/dotlottie-web-0.54.0.tgz#8795b141cf6ea0c3fd2cf2105347ec97d12216f2"
-  integrity sha512-Jc/n4i9siOXo9/1CVhKkrWC8pxxsKqKwxYfrL4DFQP/cLUAeAO0TqFPQFx9Klh1m7T+/1RPFriycOcF8gW3ZtQ==
+"@lottiefiles/dotlottie-web@0.71.0":
+  version "0.71.0"
+  resolved "https://registry.yarnpkg.com/@lottiefiles/dotlottie-web/-/dotlottie-web-0.71.0.tgz#bf066bd968459d78644bc9385ba776d48b4a7b61"
+  integrity sha512-CliQttL0Rk0or/aDQkqUJXnC9Cm5TxzNdOqy/YlzKlU6mu+XgTMwyt5/HpPiltlMeaqBmM9mOzfevpyP4QmudQ==
 
 "@napi-rs/wasm-runtime@^1.1.3":
   version "1.1.3"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1007,47 +1007,47 @@
     path-browserify "^1.0.1"
     vscode-uri "^3.0.8"
 
-"@vue/compiler-core@3.5.32":
-  version "3.5.32"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.5.32.tgz#5115ca099b04fedd8f623f93b522d914c376cbeb"
-  integrity sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==
+"@vue/compiler-core@3.5.33":
+  version "3.5.33"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.5.33.tgz#69da5fdbeadb86d5a8511cf4b80e6116c21e00f6"
+  integrity sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==
   dependencies:
     "@babel/parser" "^7.29.2"
-    "@vue/shared" "3.5.32"
+    "@vue/shared" "3.5.33"
     entities "^7.0.1"
     estree-walker "^2.0.2"
     source-map-js "^1.2.1"
 
-"@vue/compiler-dom@3.5.32", "@vue/compiler-dom@^3.5.0":
-  version "3.5.32"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.5.32.tgz#6069eae2f0d1a38263e9445f3c1da1a06e5f6534"
-  integrity sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==
+"@vue/compiler-dom@3.5.33", "@vue/compiler-dom@^3.5.0":
+  version "3.5.33"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz#20ec1f3b4d9c455cc90957e13767cd3ee16c9790"
+  integrity sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==
   dependencies:
-    "@vue/compiler-core" "3.5.32"
-    "@vue/shared" "3.5.32"
+    "@vue/compiler-core" "3.5.33"
+    "@vue/shared" "3.5.33"
 
-"@vue/compiler-sfc@3.5.32":
-  version "3.5.32"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.5.32.tgz#1f4bef6d4fbfc0cb8278a08d08c05a3afddbd2c8"
-  integrity sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==
+"@vue/compiler-sfc@3.5.33":
+  version "3.5.33"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz#647b0337dbef6e3da042576f5663ff327f635f78"
+  integrity sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==
   dependencies:
     "@babel/parser" "^7.29.2"
-    "@vue/compiler-core" "3.5.32"
-    "@vue/compiler-dom" "3.5.32"
-    "@vue/compiler-ssr" "3.5.32"
-    "@vue/shared" "3.5.32"
+    "@vue/compiler-core" "3.5.33"
+    "@vue/compiler-dom" "3.5.33"
+    "@vue/compiler-ssr" "3.5.33"
+    "@vue/shared" "3.5.33"
     estree-walker "^2.0.2"
     magic-string "^0.30.21"
-    postcss "^8.5.8"
+    postcss "^8.5.10"
     source-map-js "^1.2.1"
 
-"@vue/compiler-ssr@3.5.32":
-  version "3.5.32"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.5.32.tgz#5632a0934cb58cf88dcff1404ecf06b5a16f6816"
-  integrity sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==
+"@vue/compiler-ssr@3.5.33":
+  version "3.5.33"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz#c4e98e9427b37585351f54cb105d4ccb477e572f"
+  integrity sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==
   dependencies:
-    "@vue/compiler-dom" "3.5.32"
-    "@vue/shared" "3.5.32"
+    "@vue/compiler-dom" "3.5.33"
+    "@vue/shared" "3.5.33"
 
 "@vue/devtools-api@^6.6.4":
   version "6.6.4"
@@ -1094,43 +1094,43 @@
     path-browserify "^1.0.1"
     picomatch "^4.0.2"
 
-"@vue/reactivity@3.5.32":
-  version "3.5.32"
-  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.5.32.tgz#a4cb973095eade1ae6d899ae60ba9019d2bd21f5"
-  integrity sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==
+"@vue/reactivity@3.5.33":
+  version "3.5.33"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.5.33.tgz#d305bfef53d8825a27f3c6bb9df278dd8fe24b52"
+  integrity sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==
   dependencies:
-    "@vue/shared" "3.5.32"
+    "@vue/shared" "3.5.33"
 
-"@vue/runtime-core@3.5.32":
-  version "3.5.32"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.5.32.tgz#7ab8bc83210886aa4db69e5d72f31188628fe9d4"
-  integrity sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==
+"@vue/runtime-core@3.5.33":
+  version "3.5.33"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.5.33.tgz#1bfdc580beca0cc798c74da40985a1b40e70b708"
+  integrity sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==
   dependencies:
-    "@vue/reactivity" "3.5.32"
-    "@vue/shared" "3.5.32"
+    "@vue/reactivity" "3.5.33"
+    "@vue/shared" "3.5.33"
 
-"@vue/runtime-dom@3.5.32":
-  version "3.5.32"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.5.32.tgz#fe7815b25e55df34c6ae82a0d06be79d1342d7cf"
-  integrity sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==
+"@vue/runtime-dom@3.5.33":
+  version "3.5.33"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.5.33.tgz#7fb3fad28d84f9c4f8b1d796375c6b5b71c38c43"
+  integrity sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==
   dependencies:
-    "@vue/reactivity" "3.5.32"
-    "@vue/runtime-core" "3.5.32"
-    "@vue/shared" "3.5.32"
+    "@vue/reactivity" "3.5.33"
+    "@vue/runtime-core" "3.5.33"
+    "@vue/shared" "3.5.33"
     csstype "^3.2.3"
 
-"@vue/server-renderer@3.5.32":
-  version "3.5.32"
-  resolved "https://registry.yarnpkg.com/@vue/server-renderer/-/server-renderer-3.5.32.tgz#74579f65d271e217bdef0df62474b3c8a8dba55b"
-  integrity sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==
+"@vue/server-renderer@3.5.33":
+  version "3.5.33"
+  resolved "https://registry.yarnpkg.com/@vue/server-renderer/-/server-renderer-3.5.33.tgz#8edb8969e5250828504228f93258b85481e09482"
+  integrity sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==
   dependencies:
-    "@vue/compiler-ssr" "3.5.32"
-    "@vue/shared" "3.5.32"
+    "@vue/compiler-ssr" "3.5.33"
+    "@vue/shared" "3.5.33"
 
-"@vue/shared@3.5.32", "@vue/shared@^3.5.0":
-  version "3.5.32"
-  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.5.32.tgz#dd8ba0d709bf3f758c324a81c8897bad5e1540cf"
-  integrity sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==
+"@vue/shared@3.5.33", "@vue/shared@^3.5.0":
+  version "3.5.33"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.5.33.tgz#b41070039e91d2921edb4c38cbcc80f498a24f3a"
+  integrity sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==
 
 "@vueuse/core@^10.11.0", "@vueuse/core@^10.4.1":
   version "10.11.1"
@@ -3449,16 +3449,16 @@ vue-tsc@^3.2.4:
     "@volar/typescript" "2.4.27"
     "@vue/language-core" "3.2.4"
 
-vue@^3.5.13, vue@^3.5.32:
-  version "3.5.32"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-3.5.32.tgz#9a7cbeb181aa4b2a71c3ebac4995542cf0353de3"
-  integrity sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==
+vue@^3.5.13, vue@^3.5.33:
+  version "3.5.33"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-3.5.33.tgz#2ee5425af8ab84e255054f1f34306e370f85ea19"
+  integrity sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==
   dependencies:
-    "@vue/compiler-dom" "3.5.32"
-    "@vue/compiler-sfc" "3.5.32"
-    "@vue/runtime-dom" "3.5.32"
-    "@vue/server-renderer" "3.5.32"
-    "@vue/shared" "3.5.32"
+    "@vue/compiler-dom" "3.5.33"
+    "@vue/compiler-sfc" "3.5.33"
+    "@vue/runtime-dom" "3.5.33"
+    "@vue/server-renderer" "3.5.33"
+    "@vue/shared" "3.5.33"
 
 vuedraggable@^4.1.0:
   version "4.1.0"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1495,15 +1495,10 @@ data-urls@^7.0.0:
     whatwg-mimetype "^5.0.0"
     whatwg-url "^16.0.0"
 
-dayjs@^1.11.13:
-  version "1.11.18"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.18.tgz#835fa712aac52ab9dec8b1494098774ed7070a11"
-  integrity sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==
-
-dayjs@^1.11.19:
-  version "1.11.19"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.19.tgz#15dc98e854bb43917f12021806af897c58ae2938"
-  integrity sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==
+dayjs@^1.11.13, dayjs@^1.11.20:
+  version "1.11.20"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.20.tgz#88d919fd639dc991415da5f4cb6f1b6650811938"
+  integrity sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==
 
 debounce@^1.2.0:
   version "1.2.1"


### PR DESCRIPTION
## Summary

Backports 20 commits from `develop` onto `version-15` (Frappe v15, Python 3.10). Mirrors the precedent set by PR #86.

- **Features**: Heading 1/2/3 field types (#103), redesigned form builder layout (#105), tooltips on FieldActions buttons
- **Bug fixes**: prevent duplicate fieldnames on form save (#107), correct initial route generation (#106), multiselect option remove UI (#87), reset multiselect option input on add, semgrep findings across codebase (#98), e2e form-title auto-fill in `FormBuilderPage.goto()` (#96)
- **CI**: `merge_group` trigger to enable GitHub merge queue (#97)
- **Deps**: actions/checkout@6 (#90), actions/setup-node@6 (#88), actions/setup-python@6 (#91), actions/upload-artifact@7 (#89), `@lottiefiles/dotlottie-vue` (#93), `dayjs` 1.11.20 (#84), `postcss` 8.5.10 (#95), `vue` 3.5.33 (#110), `@vitejs/plugin-vue` (#109)

## What was NOT backported

| Commit | Reason |
|---|---|
| `dea2f7c` (#75) refactor for maintainability | Explicitly skipped on v15 (PR #86 precedent); structural changes (constants module, FORM_TO_FRAPPE_FIELDTYPE-only dispatch, FieldLabel.vue) too invasive to bring across without dedicated CI run |
| `46b31b0` (#64) / `9795bfa` (#92) Faker bumps | v15 pinned to `Faker ~=38.2.0` |
| `ebece30` / `ac65fb3` Frappe dep | v15 frappe locked to `>=15.0.0,<16.0.0` |
| `17bb3c4` (#100) migrate to oxlint | v15 stays on Biome |
| `0c4c6bc` (#113) bump oxlint | v15 has no oxlint |
| `0cf6ef1` (#82) lucide-vue-next → @lucide/vue (major rename) | Breaking; v15 stays on `lucide-vue-next` |
| `fe19483` (#112) bump @lucide/vue | v15 doesn't use @lucide/vue |
| `79e0ce3` (#80) @vueuse/core 13 → 14 | Major bump, skipped for safety |
| `0ff85f1` (#99) backport workflow | v15 doesn't backport from itself |
| `6fcb904`, `96bc2f7`, `3343548`, `47ea08e` (backport workflow CI fixes) | `.github/workflows/backport.yml` doesn't exist on v15 |

## v15 constraints preserved

| Setting | Value |
|---|---|
| `requires-python` | `>=3.10` |
| `target-version` (ruff) | `py310` |
| `frappe` dep | `>=15.0.0,<16.0.0` |
| `Faker` | `~=38.2.0` |
| Frontend lint | Biome (NOT oxlint) |
| `vue` | 3.5.33 |
| `lucide-vue-next` | 0.575.0 (NOT migrated to `@lucide/vue`) |
| `@vueuse/core` | 13.9.0 |

## Conflict resolutions

- **`form_field.py`** (#103): added `Heading 1/2/3` branch to v15's if/elif chain (`_fieldtype = "HTML"`); replaced `self.options` with `self.get_options()`; brought in `FORM_TO_FRAPPE_FIELDTYPE` dict + `_DISPLAY_ONLY_FIELDTYPES` const + `escape_html` import + `get_options()` method (dict is dead-code on v15 but kept for forward compatibility & test imports)
- **`FieldRenderer.vue`** (#103): dropped `FieldLabel` import (file doesn't exist on v15); replaced develop's `layout === 'heading'` branch with v15-style `['Heading 1', 'Heading 2', 'Heading 3'].includes(fieldData.fieldtype)` branch; restored v15's `Table` block end (`:in-edit-mode`, `:doctype` props)
- **`test_submission_validation.py`** (#103): dropped (imports `forms_pro.utils.constants` — module only exists post-refactor #75). Heading still covered by `test_form_field.py` + `frontend/e2e/specs/heading-field.spec.ts`
- **`FormBuilderContent.vue`** (#105): dropped `GripVertical` import (no longer used after refactor)
- **`FieldLabel.vue`** (#87): deleted — file doesn't exist on v15 (only the trivial `w-fit → w-full` tweak was lost)
- **`FieldActions.vue`** (new from #105): retargeted import from `@lucide/vue` to `lucide-vue-next` (v15 hasn't migrated)
- **`SubmissionFieldValue.vue`** (#103): added `as unknown as Fieldtype` casts at 3 sites — develop merged enums via refactor #75; v15 still has both `FormFieldTypes` (legacy) and `Fieldtype` (doctype-generated)
- **`frontend/package.json`**: kept `@vueuse/core ^13.9.0` (skipped major bump to 14); accepted `dayjs ^1.11.20`, `@lottiefiles/dotlottie-vue ^0.11.11`
- **CI workflows** (`ci.yml`, `linter.yml`, `typecheck.yml`): kept v15 branch filter + added `merge_group:` trigger from #97

## Test plan

- [ ] Run `bench --site <site> run-tests --app forms_pro` on Frappe v15 / Python 3.10
- [ ] Heading 1/2/3 field renders + saves submission correctly
- [ ] Multiselect remove-option UI works
- [ ] Form builder redesigned layout (#105) renders correctly
- [ ] Form save with duplicate fieldnames blocked (#107)
- [ ] Initial route generation correct (#106)
- [ ] CI passes (Python 3.10, Node 18, MariaDB 10.6)