### PR TITLE
feat(FormBuilder): add ghost class for draggable fields

### DIFF
--- a/frontend/src/components/FormBuilderContent.vue
+++ b/frontend/src/components/FormBuilderContent.vue
@@ -151,6 +151,7 @@ onClickOutside(fieldContentRef, (event) => {
                 item-key="idx"
                 tag="div"
                 handle=".handle"
+                ghost-class="opacity-50"
                 @start="isDraggingField = true"
                 @end="isDraggingField = false"
             >


### PR DESCRIPTION
Added a ghost-class with opacity to the draggable fields in the FormBuilderContent component to enhance the visual feedback during drag-and-drop actions.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced drag-and-drop visual feedback with improved opacity styling for dragged items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->