### PR TITLE
feat(FormBuilder): implement keyboard shortcut for saving forms

### DIFF
--- a/frontend/src/components/FormBuilderContent.vue
+++ b/frontend/src/components/FormBuilderContent.vue
@@ -4,7 +4,7 @@ import { LoadingIndicator, TextEditor } from "frappe-ui";
 import { useEditForm } from "@/stores/editForm";
 import { FormField } from "@/types/formfield";
 import { ref } from "vue";
-import { onClickOutside } from "@vueuse/core";
+import { onClickOutside, useEventListener } from "@vueuse/core";
 
 import FieldRenderer from "@/components/builder/FieldRenderer.vue";
 import FieldActions from "@/components/builder/FieldActions.vue";
@@ -62,6 +62,13 @@ const isDropdownOrPopover = (element: Element | null): boolean => {
 
     return false;
 };
+
+useEventListener("keydown", (event: KeyboardEvent) => {
+    if (event.metaKey && event.key === "s") {
+        event.preventDefault();
+        editFormStore.save();
+    }
+});
 
 // Set up outside click detection for the entire FormBuilderContent component
 onClickOutside(fieldContentRef, (event) => {

--- a/frontend/src/stores/editForm.ts
+++ b/frontend/src/stores/editForm.ts
@@ -115,6 +115,11 @@ export const useEditForm = defineStore("editForm", () => {
   }
 
   async function save() {
+    if (!isUnsaved.value) {
+      toast.info("No changes to save");
+      return;
+    }
+
     if (!formResource.value) {
       toast.error("No form resource available");
       return Promise.reject(new Error("No form resource available"));


### PR DESCRIPTION
Added a keyboard listener to the FormBuilderContent component that triggers the save function when the user presses "Cmd + S". Also updated the save function in the editForm store to notify users when there are no changes to save.

closes https://github.com/BuildWithHussain/forms_pro/issues/116

