### PR TITLE
feat(FormBuilder): morph action button label with TextMorph

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "frappe-ui": "^0.1.272",
     "pinia": "^3.0.3",
     "socket.io-client": "^4.8.3",
+    "torph": "^0.0.9",
     "vue": "^3.5.33",
     "vue-advanced-cropper": "^2.6.2",
     "vue-router": "^4.5.0",

--- a/frontend/src/components/FormBuilderHeader.vue
+++ b/frontend/src/components/FormBuilderHeader.vue
@@ -161,6 +161,7 @@ const openFormSubmissionPage = () => {
         </div>
         <div class="flex items-center gap-2">
             <Button
+                :aria-label="buttonConfig.label"
                 :icon-left="buttonConfig.iconLeft"
                 :variant="buttonConfig.variant"
                 :theme="buttonConfig.theme"

--- a/frontend/src/components/FormBuilderHeader.vue
+++ b/frontend/src/components/FormBuilderHeader.vue
@@ -1,13 +1,81 @@
 <script setup lang="ts">
-import { Badge, Popover, Tooltip } from "frappe-ui";
+import { Badge, Button, Popover, Tooltip, type ButtonProps } from "frappe-ui";
+import { TextMorph } from "torph/vue";
 import { ChevronDown, CloudCheck, ExternalLink, CloudOff } from "@lucide/vue";
-import { Button } from "frappe-ui";
 import { useEditForm } from "@/stores/editForm";
 import { useRouter } from "vue-router";
+import { computed, nextTick, ref, watch } from "vue";
 import Logo from "@/assets/Logo.vue";
 
 const router = useRouter();
 const editFormStore = useEditForm();
+
+const SUBMISSION_ROUTE_NAME = "Form Submission Page";
+
+type ActionConfig = {
+    label: string;
+    iconLeft: string;
+    variant: ButtonProps["variant"];
+    theme: ButtonProps["theme"];
+    handler: () => unknown;
+};
+
+function computeConfig(): ActionConfig {
+    if (editFormStore.isUnsaved && editFormStore.isPublished)
+        return {
+            label: "Save and publish",
+            iconLeft: "globe",
+            variant: "solid",
+            theme: "gray",
+            handler: editFormStore.saveAndPublish,
+        };
+    if (editFormStore.isUnsaved)
+        return {
+            label: "Save",
+            iconLeft: "",
+            variant: "solid",
+            theme: "gray",
+            handler: editFormStore.save,
+        };
+    if (editFormStore.isPublished)
+        return {
+            label: "Unpublish",
+            iconLeft: "",
+            variant: "subtle",
+            theme: "red",
+            handler: editFormStore.togglePublish,
+        };
+    return {
+        label: "Publish",
+        iconLeft: "globe",
+        variant: "solid",
+        theme: "gray",
+        handler: editFormStore.togglePublish,
+    };
+}
+
+const frozenConfig = ref<ActionConfig | null>(null);
+const buttonConfig = computed<ActionConfig>(() => frozenConfig.value ?? computeConfig());
+
+watch(
+    () => editFormStore.formResource,
+    (r) => {
+        if (!r) frozenConfig.value = null;
+    }
+);
+
+async function onAction() {
+    if (frozenConfig.value) return;
+    frozenConfig.value = computeConfig();
+    try {
+        await frozenConfig.value.handler();
+        await nextTick();
+    } catch {
+        // save() rejects on duplicate fieldnames / no-changes; togglePublish surfaces errors via toast
+    } finally {
+        frozenConfig.value = null;
+    }
+}
 
 const openFormSubmissionPage = () => {
     const route = editFormStore.originalFormData?.route;
@@ -20,10 +88,10 @@ const openFormSubmissionPage = () => {
     // Solution: Get the route definition and construct the path manually,
     // then use router.resolve() with the path string (which doesn't get encoded).
     // This way, if the path changes in router.ts, this code still works.
-    const routeRecord = router.getRoutes().find((r) => r.name === "Form Submission Page");
+    const routeRecord = router.getRoutes().find((r) => r.name === SUBMISSION_ROUTE_NAME);
     if (!routeRecord) return;
 
-    const path = routeRecord.path.replace(":route(.*)", route);
+    const path = routeRecord.path.replace(/:\w+\(.*?\)/, route);
     const routeData = router.resolve(path);
 
     window.open(routeData.href, "_blank");
@@ -31,7 +99,7 @@ const openFormSubmissionPage = () => {
 </script>
 <template>
     <header
-        class="form-builder-header flex justify-between items-center py-2 px-4 border-b h-[3rem] transition-all duration-300"
+        class="form-builder-header flex justify-between items-center py-2 px-4 border-b h-[3rem]"
         data-form-builder-component="form-builder-header"
     >
         <Popover>
@@ -59,7 +127,7 @@ const openFormSubmissionPage = () => {
                 </div>
             </template>
         </Popover>
-        <div class="flex items-center gap-2">
+        <div class="flex items-center gap-2 m-auto">
             <Badge
                 v-if="editFormStore.isUnsaved"
                 variant="subtle"
@@ -74,11 +142,7 @@ const openFormSubmissionPage = () => {
             >
                 <CloudCheck class="w-4 h-4 text-gray-500" />
             </Tooltip>
-            <Tooltip
-                v-else-if="!editFormStore.isPublished"
-                text="Form is not published"
-                placement="bottom"
-            >
+            <Tooltip v-else text="Form is not published" placement="bottom">
                 <CloudOff class="w-4 h-4 text-gray-500" />
             </Tooltip>
             <h3 class="text-base font-medium text-gray-600 text-center">
@@ -96,32 +160,15 @@ const openFormSubmissionPage = () => {
             </div>
         </div>
         <div class="flex items-center gap-2">
-            <div v-if="editFormStore.isUnsaved">
-                <Button
-                    v-if="editFormStore.isPublished"
-                    label="Save and publish"
-                    icon-left="globe"
-                    variant="solid"
-                    @click="editFormStore.saveAndPublish"
-                    :loading="editFormStore.formResource?.loading"
-                />
-                <Button
-                    v-else
-                    label="Save"
-                    variant="solid"
-                    @click="editFormStore.save"
-                    :loading="editFormStore.formResource?.loading"
-                />
-            </div>
             <Button
-                v-else
-                :label="editFormStore.isPublished ? 'Unpublish' : 'Publish'"
-                :icon-left="editFormStore.isPublished ? '' : 'globe'"
-                :variant="editFormStore.isPublished ? 'subtle' : 'solid'"
-                :theme="editFormStore.isPublished ? 'red' : 'gray'"
-                :loading="editFormStore.formResource?.loading"
-                @click="editFormStore.togglePublish"
-            />
+                :icon-left="buttonConfig.iconLeft"
+                :variant="buttonConfig.variant"
+                :theme="buttonConfig.theme"
+                :loading="editFormStore.isSaving || editFormStore.isLoading"
+                @click="onAction"
+            >
+                <TextMorph :text="buttonConfig.label" />
+            </Button>
         </div>
     </header>
 </template>

--- a/frontend/src/stores/editForm.ts
+++ b/frontend/src/stores/editForm.ts
@@ -21,6 +21,9 @@ export const useEditForm = defineStore("editForm", () => {
   const selectedField = ref<FormField | null>(null);
   const isUnsaved = computed(() => formResource.value?.isDirty || false);
   const isLoading = computed(() => formResource.value?.loading || false);
+  const isSaving = computed(
+    () => formResource.value?.setValue?.loading || false
+  );
   const isPublished = computed(
     () => formResource.value?.doc?.is_published || false
   );
@@ -165,25 +168,24 @@ export const useEditForm = defineStore("editForm", () => {
   }
 
   function togglePublish() {
-    if (formResource.value?.doc) {
-      formResource.value.setValue.submit(
-        {
-          is_published: !formResource.value.doc.is_published,
+    if (!formResource.value?.doc) return Promise.resolve();
+    return formResource.value.setValue.submit(
+      {
+        is_published: !formResource.value.doc.is_published,
+      },
+      {
+        onSuccess: () => {
+          if (formResource.value.doc.is_published) {
+            toast.success("Form published successfully");
+          } else {
+            toast.info("Form unpublished successfully");
+          }
         },
-        {
-          onSuccess: () => {
-            if (formResource.value.doc.is_published) {
-              toast.success("Form published successfully");
-            } else {
-              toast.info("Form unpublished successfully");
-            }
-          },
-          onError: () => {
-            toast.error("Failed to publish form");
-          },
-        }
-      );
-    }
+        onError: () => {
+          toast.error("Failed to publish form");
+        },
+      }
+    );
   }
 
   function updateFormData(data: Partial<Form>) {
@@ -254,6 +256,7 @@ export const useEditForm = defineStore("editForm", () => {
     // Computed
     originalFormData,
     isLoading,
+    isSaving,
     isError,
     formData,
     fields,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3290,6 +3290,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+torph@^0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/torph/-/torph-0.0.9.tgz#00026fa3f14685b5a380e87202674bb2aa84d38e"
+  integrity sha512-WrFMtJwqXCfIXbLNuTOwHWff0XVm/Ewctb+71bFis3HykPvCXl1CHXapU0r67pQhAI323fsA1L2pGPeqxXeRRA==
+
 tough-cookie@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-6.0.1.tgz#a495f833836609ed983c19bc65639cfbceb54c76"


### PR DESCRIPTION
## Summary

- Adds `torph` dep and integrates `TextMorph` for animated action button label transitions
- Fixes button label flickering through incorrect intermediate states on click (root cause: frappe-ui's `setValue.submit` mutates `doc` optimistically before `originalDoc` syncs, causing a brief `isDirty=true` window that triggers extra reactive renders)
- Exposes `isSaving` from the edit form store and makes `togglePublish` return a promise so consumers can await settled state

## How the fix works

On click, the button config is snapshotted _before_ the handler mutates doc state. The snapshot is held until the `setValue.submit` promise resolves and Vue's deep `isDirty` watcher has had a tick to settle — then the live config takes over. Double-clicks are ignored while frozen.

## Test plan

- [x] Click **Save** — label stays "Save" until save completes, then shows "Publish"
- [x] Click **Publish** — label stays "Publish" until complete, then shows "Unpublish"
- [x] Click **Unpublish** — label stays "Unpublish" until complete, then shows "Publish"
- [x] Click **Save and publish** — label stays "Save and publish" until complete, then shows "Unpublish"
- [x] Save with duplicate fieldnames — dialog appears, label unchanged after dismiss
- [x] Network error on publish — toast fires, label returns to pre-click state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Enhanced form save and publish state management to prevent action conflicts and improve overall reliability during form submission operations
- Improved form header layout with refined tooltip interactions providing clearer visual feedback and guidance to users
- Optimized form loading state tracking for more accurate representation of background save and publish operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->