### PR TITLE
feat: multi-column form layout with column stacking

### DIFF
--- a/forms_pro/forms_pro/doctype/form/test_form.py
+++ b/forms_pro/forms_pro/doctype/form/test_form.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe.tests import IntegrationTestCase
 
+from forms_pro.patches.v0_x.backfill_field_layout import execute as backfill_execute
 from forms_pro.utils.teams import get_user_teams
 
 # On IntegrationTestCase, the doctype test records and all
@@ -202,3 +203,104 @@ class IntegrationTestForm(IntegrationTestCase):
         self.assertEqual(status_field.fieldtype, "Select")
         self.assertEqual(status_field.options, "Active\nInactive\nPending")
         self.assertEqual(status_field.default, "Active")
+
+    def test_layout_fields_do_not_affect_doctype_sync(self):
+        """Changing row_index/column_index on FormField must not modify the linked DocType."""
+        self.test_form.append(
+            "fields",
+            {"label": "Full Name", "fieldname": "full_name", "fieldtype": "Data"},
+        )
+        self.test_form.save()
+
+        doctype_doc = frappe.get_doc("DocType", self.test_doctype_name)
+        fields_before = [(f.fieldname, f.fieldtype, f.label) for f in doctype_doc.fields]
+
+        # Mutate only layout fields and save
+        self.test_form.fields[0].row_index = 5
+        self.test_form.fields[0].column_index = 3
+        self.test_form.save()
+
+        doctype_doc = frappe.get_doc("DocType", self.test_doctype_name)
+        fields_after = [(f.fieldname, f.fieldtype, f.label) for f in doctype_doc.fields]
+
+        self.assertEqual(fields_before, fields_after)
+
+
+class TestBackfillFieldLayoutPatch(IntegrationTestCase):
+    """Backfill patch sets row_index = idx-1, column_index = 0 for all FormField rows."""
+
+    _test_doctype_name = "Backfill Patch Test DocType"
+
+    def setUp(self):
+        from forms_pro.tests import FORMS_PRO_TEST_USER
+        from forms_pro.utils.teams import get_user_teams
+
+        if not frappe.db.exists("DocType", self._test_doctype_name):
+            frappe.get_doc(
+                {
+                    "doctype": "DocType",
+                    "name": self._test_doctype_name,
+                    "module": "Custom",
+                    "custom": 1,
+                    "fields": [{"fieldname": "title", "fieldtype": "Data", "label": "Title"}],
+                }
+            ).insert()
+
+        self.test_team = get_user_teams(FORMS_PRO_TEST_USER)[0]["name"]
+
+    def tearDown(self):
+        for name in frappe.get_all("Form", filters={"linked_doctype": self._test_doctype_name}, pluck="name"):
+            frappe.delete_doc("Form", name, force=True, ignore_permissions=True)
+        if frappe.db.exists("DocType", self._test_doctype_name):
+            frappe.delete_doc("DocType", self._test_doctype_name, force=True)
+
+    def _make_form(self) -> str:
+        form = frappe.get_doc(
+            {
+                "doctype": "Form",
+                "title": "Patch Test Form",
+                "linked_doctype": self._test_doctype_name,
+                "linked_team_id": self.test_team,
+                "fields": [
+                    {"label": "Field A", "fieldname": "field_a", "fieldtype": "Data"},
+                    {"label": "Field B", "fieldname": "field_b", "fieldtype": "Data"},
+                    {"label": "Field C", "fieldname": "field_c", "fieldtype": "Data"},
+                ],
+            }
+        )
+        form.insert(ignore_permissions=True)
+        return form.name
+
+    def test_patch_sets_row_index_from_idx(self):
+        form_name = self._make_form()
+        frappe.db.sql(
+            "UPDATE `tabForm Field` SET row_index = 99, column_index = 99 WHERE parent = %s",
+            form_name,
+        )
+
+        backfill_execute()
+
+        fields = frappe.get_all(
+            "Form Field",
+            filters={"parent": form_name},
+            fields=["fieldname", "idx", "row_index", "column_index"],
+            order_by="idx asc",
+        )
+        for f in fields:
+            self.assertEqual(f.row_index, f.idx - 1, f"row_index wrong for {f.fieldname}")
+            self.assertEqual(f.column_index, 0, f"column_index wrong for {f.fieldname}")
+
+    def test_patch_is_idempotent(self):
+        form_name = self._make_form()
+        backfill_execute()
+        backfill_execute()
+
+        fields = frappe.get_all(
+            "Form Field",
+            filters={"parent": form_name},
+            fields=["idx", "row_index", "column_index"],
+            order_by="idx asc",
+        )
+        for f in fields:
+            self.assertEqual(f.row_index, f.idx - 1)
+            self.assertEqual(f.column_index, 0)

--- a/forms_pro/forms_pro/doctype/form_field/form_field.json
+++ b/forms_pro/forms_pro/doctype/form_field/form_field.json
@@ -6,6 +6,8 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "row_index",
+  "column_index",
   "reqd",
   "hidden",
   "label",
@@ -75,13 +77,27 @@
    "fieldname": "hidden",
    "fieldtype": "Check",
    "label": "Hidden"
+  },
+  {
+   "fieldname": "row_index",
+   "fieldtype": "Int",
+   "label": "Row Index",
+   "non_negative": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_index",
+   "fieldtype": "Int",
+   "label": "Column Index",
+   "non_negative": 1,
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-04-25 20:32:10.994784",
+ "modified": "2026-05-05 00:02:48.020615",
  "modified_by": "Administrator",
  "module": "Forms Pro",
  "name": "Form Field",

--- a/forms_pro/forms_pro/doctype/form_field/form_field.json
+++ b/forms_pro/forms_pro/doctype/form_field/form_field.json
@@ -8,6 +8,7 @@
  "field_order": [
   "row_index",
   "column_index",
+  "cell_index",
   "reqd",
   "hidden",
   "label",
@@ -89,6 +90,13 @@
    "fieldname": "column_index",
    "fieldtype": "Int",
    "label": "Column Index",
+   "non_negative": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "cell_index",
+   "fieldtype": "Int",
+   "label": "Cell Index",
    "non_negative": 1,
    "read_only": 1
   }

--- a/forms_pro/forms_pro/doctype/form_field/form_field.py
+++ b/forms_pro/forms_pro/doctype/form_field/form_field.py
@@ -48,6 +48,7 @@ class FormField(Document):
     if TYPE_CHECKING:
         from frappe.types import DF
 
+        cell_index: DF.Int
         column_index: DF.Int
         conditional_logic: DF.Code | None
         default: DF.SmallText | None

--- a/forms_pro/forms_pro/doctype/form_field/form_field.py
+++ b/forms_pro/forms_pro/doctype/form_field/form_field.py
@@ -48,6 +48,7 @@ class FormField(Document):
     if TYPE_CHECKING:
         from frappe.types import DF
 
+        column_index: DF.Int
         conditional_logic: DF.Code | None
         default: DF.SmallText | None
         description: DF.SmallText | None
@@ -83,6 +84,7 @@ class FormField(Document):
         parentfield: DF.Data
         parenttype: DF.Data
         reqd: DF.Check
+        row_index: DF.Int
     # end: auto-generated types
 
     @property

--- a/forms_pro/patches.txt
+++ b/forms_pro/patches.txt
@@ -5,3 +5,4 @@ forms_pro.patches.0_1_beta.create_user_forms_module_def
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
+forms_pro.patches.v0_x.backfill_field_layout

--- a/forms_pro/patches/v0_x/backfill_field_layout.py
+++ b/forms_pro/patches/v0_x/backfill_field_layout.py
@@ -8,6 +8,10 @@ def execute():
     Uses direct SQL to avoid triggering Form.on_update / set_doctype_fields().
     Idempotent: WHERE clause skips already-correct rows.
     """
+    # row_index / column_index on `tabForm Field` are Int NOT NULL DEFAULT 0
+    # (Frappe's schema sync). Legacy rows pre-dating these columns therefore
+    # land on 0 after migration, not NULL — so a plain `!=` predicate is
+    # enough. No IS NULL branch needed.
     frappe.db.sql("""
         UPDATE `tabForm Field`
         SET row_index = idx - 1, column_index = 0

--- a/forms_pro/patches/v0_x/backfill_field_layout.py
+++ b/forms_pro/patches/v0_x/backfill_field_layout.py
@@ -1,0 +1,15 @@
+import frappe
+
+
+def execute():
+    """
+    Backfill row_index / column_index on existing FormField records.
+    Each field becomes its own single-column row, preserving vertical order.
+    Uses direct SQL to avoid triggering Form.on_update / set_doctype_fields().
+    Idempotent: WHERE clause skips already-correct rows.
+    """
+    frappe.db.sql("""
+        UPDATE `tabForm Field`
+        SET row_index = idx - 1, column_index = 0
+        WHERE row_index != idx - 1 OR column_index != 0
+    """)

--- a/forms_pro/tests/test_form_field.py
+++ b/forms_pro/tests/test_form_field.py
@@ -77,7 +77,7 @@ class TestFormFieldToFrappeField(IntegrationTestCase):
 
 
 class TestLayoutFieldsNotSyncedToDoctype(IntegrationTestCase):
-    """row_index and column_index are layout-only and must never appear in to_frappe_field."""
+    """row_index, column_index, cell_index are layout-only and must never appear in to_frappe_field."""
 
     def test_row_index_excluded_from_frappe_field(self):
         field = _build_field("Data", label="Name", fieldname="name_field")
@@ -89,12 +89,19 @@ class TestLayoutFieldsNotSyncedToDoctype(IntegrationTestCase):
         field.column_index = 2
         self.assertNotIn("column_index", field.to_frappe_field)
 
+    def test_cell_index_excluded_from_frappe_field(self):
+        field = _build_field("Data", label="Name", fieldname="name_field")
+        field.cell_index = 4
+        self.assertNotIn("cell_index", field.to_frappe_field)
+
     def test_layout_fields_excluded_for_all_fieldtypes(self):
         for fieldtype in FORM_TO_FRAPPE_FIELDTYPE:
             with self.subTest(fieldtype=fieldtype):
                 field = _build_field(fieldtype, label="Test", fieldname="test_f")
                 field.row_index = 1
                 field.column_index = 1
+                field.cell_index = 1
                 result = field.to_frappe_field
                 self.assertNotIn("row_index", result)
                 self.assertNotIn("column_index", result)
+                self.assertNotIn("cell_index", result)

--- a/forms_pro/tests/test_form_field.py
+++ b/forms_pro/tests/test_form_field.py
@@ -74,3 +74,27 @@ class TestFormFieldToFrappeField(IntegrationTestCase):
             with self.subTest(fieldtype=fieldtype):
                 self.assertIn(fieldtype, FORM_TO_FRAPPE_FIELDTYPE)
                 self.assertEqual(FORM_TO_FRAPPE_FIELDTYPE[fieldtype]["fieldtype"], "HTML")
+
+
+class TestLayoutFieldsNotSyncedToDoctype(IntegrationTestCase):
+    """row_index and column_index are layout-only and must never appear in to_frappe_field."""
+
+    def test_row_index_excluded_from_frappe_field(self):
+        field = _build_field("Data", label="Name", fieldname="name_field")
+        field.row_index = 3
+        self.assertNotIn("row_index", field.to_frappe_field)
+
+    def test_column_index_excluded_from_frappe_field(self):
+        field = _build_field("Data", label="Name", fieldname="name_field")
+        field.column_index = 2
+        self.assertNotIn("column_index", field.to_frappe_field)
+
+    def test_layout_fields_excluded_for_all_fieldtypes(self):
+        for fieldtype in FORM_TO_FRAPPE_FIELDTYPE:
+            with self.subTest(fieldtype=fieldtype):
+                field = _build_field(fieldtype, label="Test", fieldname="test_f")
+                field.row_index = 1
+                field.column_index = 1
+                result = field.to_frappe_field
+                self.assertNotIn("row_index", result)
+                self.assertNotIn("column_index", result)

--- a/frontend/e2e/helpers/form-builder.ts
+++ b/frontend/e2e/helpers/form-builder.ts
@@ -1,7 +1,206 @@
-import type { Page } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
 
 export class FormBuilderPage {
   constructor(private page: Page) {}
+
+  // ---- Layout introspection helpers ----
+
+  fieldCard(label: string): Locator {
+    return this.page.locator(
+      `[data-form-builder-component="field-card"][data-field-label="${label}"]`
+    );
+  }
+
+  // Wait for the builder to finish hydrating with the form's fields (the
+  // form fetch is async after navigation; helps avoid races when tests load
+  // pre-built layouts via the REST API).
+  async waitForFields(labels: string[]) {
+    for (const label of labels) {
+      await this.fieldCard(label).waitFor({ state: "visible", timeout: 15000 });
+    }
+  }
+
+  async rowCount(): Promise<number> {
+    return this.page
+      .locator('[data-form-builder-component="form-row"]')
+      .count();
+  }
+
+  async columnCount(rowIdx: number): Promise<number> {
+    return this.page
+      .locator(
+        `[data-form-builder-component="cell-column"][data-row-index="${rowIdx}"]`
+      )
+      .count();
+  }
+
+  async cellCount(rowIdx: number, colIdx: number): Promise<number> {
+    return this.page
+      .locator(
+        `[data-form-builder-component="field-card"][data-row-index="${rowIdx}"][data-col-index="${colIdx}"]`
+      )
+      .count();
+  }
+
+  // ---- Drag mechanics ----
+  // SortableJS + Playwright is fragile. Use a real mouse path with intermediate
+  // steps so SortableJS sees a continuous dragover sequence.
+  private async dragWithRealMouse(
+    sourceHandle: Locator,
+    targetCenter: { x: number; y: number },
+    waypoints: { x: number; y: number }[] = []
+  ) {
+    const handleBox = await sourceHandle.boundingBox();
+    if (!handleBox) throw new Error("source handle not visible");
+
+    const start = {
+      x: handleBox.x + handleBox.width / 2,
+      y: handleBox.y + handleBox.height / 2,
+    };
+
+    await this.page.mouse.move(start.x, start.y);
+    await this.page.mouse.down();
+    // Small initial nudge — SortableJS needs movement to begin drag
+    await this.page.mouse.move(start.x + 4, start.y + 4, { steps: 4 });
+
+    // Walk through caller-supplied waypoints (lets the path avoid crossing
+    // other sortable instances en route). Each leg uses many steps so
+    // SortableJS receives a continuous dragover/pointer-move sequence.
+    let prev = start;
+    for (const wp of waypoints) {
+      await this.page.mouse.move(wp.x, wp.y, { steps: 10 });
+      prev = wp;
+    }
+
+    // Approach the target with a midpoint then arrival
+    await this.page.mouse.move(
+      (prev.x + targetCenter.x) / 2,
+      (prev.y + targetCenter.y) / 2,
+      { steps: 10 }
+    );
+    await this.page.mouse.move(targetCenter.x, targetCenter.y, { steps: 12 });
+
+    // Wiggle at target — forces a fresh dragover/pointer-move sequence on
+    // the final drop target so SortableJS commits the swap there, not
+    // somewhere we crossed earlier in the path.
+    await this.page.waitForTimeout(80);
+    await this.page.mouse.move(targetCenter.x + 2, targetCenter.y + 2, {
+      steps: 4,
+    });
+    await this.page.mouse.move(targetCenter.x, targetCenter.y, { steps: 4 });
+    await this.page.waitForTimeout(120);
+    await this.page.mouse.up();
+  }
+
+  private dragHandle(card: Locator): Locator {
+    return card.locator(".handle");
+  }
+
+  async dragFieldOntoCell(
+    sourceLabel: string,
+    targetLabel: string,
+    position: "above" | "below"
+  ) {
+    const source = this.fieldCard(sourceLabel);
+    const target = this.fieldCard(targetLabel);
+
+    // Hover the target's group first so its handle/actions render (needed for
+    // the source handle to be visible — actions only show on hover/select).
+    await source.hover();
+    const handle = this.dragHandle(source);
+    await handle.waitFor({ state: "visible" });
+
+    const sourceBox = await source.boundingBox();
+    const box = await target.boundingBox();
+    if (!sourceBox) throw new Error(`source card '${sourceLabel}' not visible`);
+    if (!box) throw new Error(`target card '${targetLabel}' not visible`);
+
+    // Position cursor in upper / lower portion of target card
+    const yOffset =
+      position === "above" ? box.height * 0.25 : box.height * 0.75;
+    const targetCenter = {
+      x: box.x + box.width / 2,
+      y: box.y + yOffset,
+    };
+
+    // If the drag crosses rows (different y bands), route through a
+    // waypoint that lives in the row drop zone between rows. This avoids
+    // accidentally swapping into another sortable instance (e.g. the
+    // neighbouring column in the source row) while passing through.
+    const waypoints: { x: number; y: number }[] = [];
+    const sourceMidY = sourceBox.y + sourceBox.height / 2;
+    const verticalGapMidpoint = (sourceMidY + targetCenter.y) / 2;
+    const isCrossRow = Math.abs(targetCenter.y - sourceMidY) > sourceBox.height;
+    if (isCrossRow) {
+      // Drop straight down (or up) along the source's x first so we leave
+      // the source's row through the row drop zone, then slide horizontally
+      // toward the target before approaching.
+      waypoints.push({
+        x: sourceBox.x + sourceBox.width / 2,
+        y: verticalGapMidpoint,
+      });
+      waypoints.push({ x: targetCenter.x, y: verticalGapMidpoint });
+    }
+
+    await this.dragWithRealMouse(handle, targetCenter, waypoints);
+  }
+
+  // Drag a field onto a ColumnDropZone (gap between/around columns within a row).
+  // Targets the zone with [data-at-row=atRow][data-at-col=atCol].
+  async dragFieldToColumnZone(
+    sourceLabel: string,
+    atRow: number,
+    atCol: number
+  ) {
+    const source = this.fieldCard(sourceLabel);
+    await source.hover();
+    const handle = this.dragHandle(source);
+    await handle.waitFor({ state: "visible" });
+
+    const zone = this.page.locator(
+      `[data-form-builder-component="column-drop-zone"][data-at-row="${atRow}"][data-at-col="${atCol}"]`
+    );
+    const box = await zone.boundingBox();
+    if (!box) {
+      throw new Error(`column drop zone (${atRow},${atCol}) not visible`);
+    }
+
+    await this.dragWithRealMouse(handle, {
+      x: box.x + box.width / 2,
+      y: box.y + box.height / 2,
+    });
+  }
+
+  // Click the eject button on the field's card (action bar).
+  // Action bar only mounts visible on hover/select — hover first.
+  async ejectField(label: string) {
+    const card = this.fieldCard(label);
+    await card.hover();
+    const ejectBtn = card.locator(
+      '[data-form-builder-component="eject-button"]'
+    );
+    await ejectBtn.waitFor({ state: "visible" });
+    await ejectBtn.click();
+  }
+
+  // Drag a field onto a RowDropZone above row atRow.
+  async dragFieldToRowZone(sourceLabel: string, atRow: number) {
+    const source = this.fieldCard(sourceLabel);
+    await source.hover();
+    const handle = this.dragHandle(source);
+    await handle.waitFor({ state: "visible" });
+
+    const zone = this.page.locator(
+      `[data-form-builder-component="row-drop-zone"][data-at-row="${atRow}"]`
+    );
+    const box = await zone.boundingBox();
+    if (!box) throw new Error(`row drop zone at row ${atRow} not visible`);
+
+    await this.dragWithRealMouse(handle, {
+      x: box.x + box.width / 2,
+      y: box.y + box.height / 2,
+    });
+  }
 
   async goto(
     formId: string,

--- a/frontend/e2e/specs/form-layout.spec.ts
+++ b/frontend/e2e/specs/form-layout.spec.ts
@@ -1,0 +1,325 @@
+import { test, expect } from "../fixtures/test-data.fixture";
+import { FormBuilderPage } from "../helpers/form-builder";
+import { SubmissionPage } from "../helpers/submission";
+
+// Helper: set a form's field list via REST so the builder loads with a known
+// row/column/cell layout. Mirrors the pattern used in heading-field.spec.ts.
+async function setFormFields(
+  apiContext: import("@playwright/test").APIRequestContext,
+  formId: string,
+  fields: Array<{
+    label: string;
+    fieldtype?: string;
+    row_index: number;
+    column_index?: number;
+    cell_index?: number;
+  }>
+) {
+  await apiContext.put(`/api/resource/Form/${formId}`, {
+    data: {
+      fields: fields.map((f, i) => ({
+        idx: i + 1,
+        fieldtype: f.fieldtype ?? "Data",
+        label: f.label,
+        fieldname: f.label.toLowerCase(),
+        reqd: 0,
+        row_index: f.row_index,
+        column_index: f.column_index ?? 0,
+        cell_index: f.cell_index ?? 0,
+      })),
+    },
+  });
+}
+
+test.describe("Multi-column form layout", () => {
+  test("cell stacks into existing column on drag", async ({
+    page,
+    createForm,
+    apiContext,
+  }) => {
+    const formId = await createForm();
+    await setFormFields(apiContext, formId, [
+      { label: "A", row_index: 0 },
+      { label: "B", row_index: 1 },
+    ]);
+
+    const builder = new FormBuilderPage(page);
+    await builder.goto(formId, { skipTitleFill: true });
+
+    // Sanity: starting layout is 2 rows, 1 column each, 1 cell each
+    await builder.waitForFields(["A", "B"]);
+    expect(await builder.rowCount()).toBe(2);
+
+    await builder.dragFieldOntoCell("B", "A", "above");
+
+    // After drag: 1 row, 1 column, 2 cells stacked in (row 0, col 0)
+    await expect.poll(() => builder.rowCount()).toBe(1);
+    await expect.poll(() => builder.columnCount(0)).toBe(1);
+    await expect.poll(() => builder.cellCount(0, 0)).toBe(2);
+  });
+
+  test("column drop zone creates new column", async ({
+    page,
+    createForm,
+    apiContext,
+  }) => {
+    const formId = await createForm();
+    await setFormFields(apiContext, formId, [
+      { label: "A", row_index: 0 },
+      { label: "B", row_index: 1 },
+    ]);
+
+    const builder = new FormBuilderPage(page);
+    await builder.goto(formId, { skipTitleFill: true });
+
+    await builder.waitForFields(["A", "B"]);
+
+    // Drop B into the column drop zone right of A (row 0, col 1)
+    await builder.dragFieldToColumnZone("B", 0, 1);
+
+    await expect.poll(() => builder.rowCount()).toBe(1);
+    await expect.poll(() => builder.columnCount(0)).toBe(2);
+    await expect.poll(() => builder.cellCount(0, 0)).toBe(1);
+    await expect.poll(() => builder.cellCount(0, 1)).toBe(1);
+  });
+
+  test("row drop zone creates new row", async ({
+    page,
+    createForm,
+    apiContext,
+  }) => {
+    const formId = await createForm();
+    // 2-column row of A, B in row 0
+    await setFormFields(apiContext, formId, [
+      { label: "A", row_index: 0, column_index: 0 },
+      { label: "B", row_index: 0, column_index: 1 },
+    ]);
+
+    const builder = new FormBuilderPage(page);
+    await builder.goto(formId, { skipTitleFill: true });
+
+    await builder.waitForFields(["A", "B"]);
+    expect(await builder.columnCount(0)).toBe(2);
+
+    // Drop B above current row — B becomes row 0, A pushed to row 1
+    await builder.dragFieldToRowZone("B", 0);
+
+    await expect.poll(() => builder.rowCount()).toBe(2);
+    await expect.poll(() => builder.columnCount(0)).toBe(1);
+    await expect.poll(() => builder.columnCount(1)).toBe(1);
+  });
+
+  test("eject moves cell to new row", async ({
+    page,
+    createForm,
+    apiContext,
+  }) => {
+    const formId = await createForm();
+    // 2-cell column: A on top (cell 0), B below (cell 1) — same row, same col
+    await setFormFields(apiContext, formId, [
+      { label: "A", row_index: 0, column_index: 0, cell_index: 0 },
+      { label: "B", row_index: 0, column_index: 0, cell_index: 1 },
+    ]);
+
+    const builder = new FormBuilderPage(page);
+    await builder.goto(formId, { skipTitleFill: true });
+
+    await builder.waitForFields(["A", "B"]);
+    expect(await builder.cellCount(0, 0)).toBe(2);
+
+    // Eject A — A moves to its own row, B stays put
+    await builder.ejectField("A");
+
+    await expect.poll(() => builder.rowCount()).toBe(2);
+    // No multi-cell column should remain
+    const rows = await builder.rowCount();
+    for (let r = 0; r < rows; r++) {
+      const cols = await builder.columnCount(r);
+      for (let c = 0; c < cols; c++) {
+        expect(await builder.cellCount(r, c)).toBe(1);
+      }
+    }
+  });
+
+  test("cross-row drag collapses source column", async ({
+    page,
+    createForm,
+    apiContext,
+  }) => {
+    const formId = await createForm();
+    // 2 rows x 2 cols: A, B / C, D
+    await setFormFields(apiContext, formId, [
+      { label: "A", row_index: 0, column_index: 0 },
+      { label: "B", row_index: 0, column_index: 1 },
+      { label: "C", row_index: 1, column_index: 0 },
+      { label: "D", row_index: 1, column_index: 1 },
+    ]);
+
+    const builder = new FormBuilderPage(page);
+    await builder.goto(formId, { skipTitleFill: true });
+
+    await builder.waitForFields(["A", "B", "C", "D"]);
+    expect(await builder.columnCount(0)).toBe(2);
+    expect(await builder.columnCount(1)).toBe(2);
+
+    // Stack B onto C — moves B into row 1, col 0 (cell 0 above C)
+    await builder.dragFieldOntoCell("B", "C", "above");
+
+    // Row 0 collapses to 1 column (only A); row 1 still has 2 columns
+    await expect.poll(() => builder.rowCount()).toBe(2);
+    await expect.poll(() => builder.columnCount(0)).toBe(1);
+    await expect.poll(() => builder.columnCount(1)).toBe(2);
+    await expect.poll(() => builder.cellCount(1, 0)).toBe(2);
+  });
+
+  test("within-column reorder renumbers cell_index", async ({
+    page,
+    createForm,
+    apiContext,
+  }) => {
+    const formId = await createForm();
+    // 2-cell column: A on top, B on bottom
+    await setFormFields(apiContext, formId, [
+      { label: "A", row_index: 0, column_index: 0, cell_index: 0 },
+      { label: "B", row_index: 0, column_index: 0, cell_index: 1 },
+    ]);
+
+    const builder = new FormBuilderPage(page);
+    await builder.goto(formId, { skipTitleFill: true });
+
+    await builder.waitForFields(["A", "B"]);
+
+    // Drag B above A — DOM order should flip to B, A
+    await builder.dragFieldOntoCell("B", "A", "above");
+
+    const labelsInColumn = () =>
+      page
+        .locator(
+          '[data-form-builder-component="cell-column"][data-row-index="0"][data-col-index="0"] [data-form-builder-component="field-card"]'
+        )
+        .evaluateAll((els) =>
+          els.map((e) => (e as HTMLElement).getAttribute("data-field-label"))
+        );
+
+    await expect.poll(labelsInColumn).toEqual(["B", "A"]);
+  });
+
+  test("mobile viewport stacks columns vertically", async ({
+    browser,
+    createPublishedForm,
+    apiContext,
+  }) => {
+    const { formId, route } = await createPublishedForm();
+    // 2-column row of A, B (use Data fieldtype so they render as inputs)
+    await apiContext.put(`/api/resource/Form/${formId}`, {
+      data: {
+        fields: [
+          {
+            idx: 1,
+            fieldtype: "Data",
+            label: "A",
+            fieldname: "a",
+            row_index: 0,
+            column_index: 0,
+            cell_index: 0,
+          },
+          {
+            idx: 2,
+            fieldtype: "Data",
+            label: "B",
+            fieldname: "b",
+            row_index: 0,
+            column_index: 1,
+            cell_index: 0,
+          },
+        ],
+      },
+    });
+
+    // Mobile viewport
+    const guestCtx = await browser.newContext({
+      viewport: { width: 375, height: 800 },
+    });
+    const guestPage = await guestCtx.newPage();
+    const submission = new SubmissionPage(guestPage);
+    await submission.goto(route);
+
+    const row = guestPage.locator('[data-form-renderer-component="form-row"]');
+    await expect(row).toBeVisible({ timeout: 10000 });
+
+    const flexDirection = await row.evaluate(
+      (el) => getComputedStyle(el as HTMLElement).flexDirection
+    );
+    expect(flexDirection).toBe("column");
+
+    await guestCtx.close();
+  });
+
+  test("hidden field unmounts, no empty column", async ({
+    browser,
+    createPublishedForm,
+    apiContext,
+  }) => {
+    const { formId, route } = await createPublishedForm();
+
+    // 2-column row: A (col 0), B (col 1). A carries a conditional rule that
+    // hides B whenever A is empty (it always is on first render), exercising
+    // the "hide a column entirely when its only field is hidden" path.
+    const conditionalLogic = JSON.stringify({
+      target_field: "b",
+      conditions: [{ fieldname: "a", operator: "Is Empty", value: "" }],
+      action: "Hide Field",
+    });
+
+    await apiContext.put(`/api/resource/Form/${formId}`, {
+      data: {
+        fields: [
+          {
+            idx: 1,
+            fieldtype: "Data",
+            label: "A",
+            fieldname: "a",
+            row_index: 0,
+            column_index: 0,
+            cell_index: 0,
+            conditional_logic: conditionalLogic,
+          },
+          {
+            idx: 2,
+            fieldtype: "Data",
+            label: "B",
+            fieldname: "b",
+            row_index: 0,
+            column_index: 1,
+            cell_index: 0,
+          },
+        ],
+      },
+    });
+
+    const guestCtx = await browser.newContext();
+    const guestPage = await guestCtx.newPage();
+    const submission = new SubmissionPage(guestPage);
+    await submission.goto(route);
+
+    // Wait for the Submit button — confirms the renderer mounted past
+    // initial load (the form layout is reactive to the API fetch).
+    await expect(guestPage.getByRole("button", { name: "Submit" })).toBeVisible(
+      { timeout: 10000 }
+    );
+
+    // Row should render with exactly one column (the one holding A); the
+    // column wrapping B must be unmounted (v-if), not just emptied.
+    const row = guestPage.locator('[data-form-renderer-component="form-row"]');
+    await expect(row).toHaveCount(1);
+    const columns = row.locator('[data-form-renderer-component="form-column"]');
+    await expect(columns).toHaveCount(1);
+
+    // Only A's input should render — B is unmounted by the conditional rule
+    // (frappe-ui's FormControl doesn't expose `name`, so count text inputs
+    // inside the form column instead).
+    await expect(columns.locator("input[type='text']")).toHaveCount(1);
+
+    await guestCtx.close();
+  });
+});

--- a/frontend/src/components/FormBuilderContent.vue
+++ b/frontend/src/components/FormBuilderContent.vue
@@ -14,6 +14,7 @@ const editFormStore = useEditForm();
 
 const fieldContentRef = ref<HTMLElement | null>(null);
 const isDraggingField = ref(false);
+const draggingFromRow = ref<number | null>(null);
 
 const groupedRows = useGroupedRows(computed(() => editFormStore.fields));
 
@@ -176,7 +177,6 @@ onClickOutside(fieldContentRef, (event) => {
         <div class="flex flex-col gap-3">
             <template v-for="(row, rIdx) in groupedRows" :key="rowIndexOf(row, rIdx)">
                 <RowDropZone
-                    v-if="rIdx > 0"
                     :atRow="rowIndexOf(row, rIdx)"
                     :isDragging="isDraggingField"
                     @drop="onRowZoneDrop"
@@ -190,13 +190,32 @@ onClickOutside(fieldContentRef, (event) => {
                     tag="div"
                     class="flex flex-row gap-2 items-stretch"
                     @change="(evt: any) => onFieldChange(evt, rowIndexOf(row, rIdx))"
-                    @start="isDraggingField = true"
-                    @end="isDraggingField = false"
+                    @start="
+                        () => {
+                            isDraggingField = true;
+                            draggingFromRow = rowIndexOf(row, rIdx);
+                        }
+                    "
+                    @end="
+                        () => {
+                            isDraggingField = false;
+                            draggingFromRow = null;
+                        }
+                    "
                 >
                     <template #item="{ element: field }">
                         <FieldCard :field="field" :isDraggingAnyField="isDraggingField" />
                     </template>
                 </draggableComponent>
+                <RowDropZone
+                    v-if="
+                        rIdx === groupedRows.length - 1 &&
+                        draggingFromRow !== rowIndexOf(row, rIdx)
+                    "
+                    :atRow="rowIndexOf(row, rIdx) + 1"
+                    :isDragging="isDraggingField"
+                    @drop="onRowZoneDrop"
+                />
             </template>
         </div>
     </div>

--- a/frontend/src/components/FormBuilderContent.vue
+++ b/frontend/src/components/FormBuilderContent.vue
@@ -15,11 +15,9 @@ const editFormStore = useEditForm();
 
 const fieldContentRef = ref<HTMLElement | null>(null);
 const isDraggingField = ref(false);
-const draggingFromRow = ref<number | null>(null);
 
 function resetDragState() {
     isDraggingField.value = false;
-    draggingFromRow.value = null;
 }
 
 useEventListener(document, "pointerup", () => {
@@ -244,18 +242,8 @@ onClickOutside(fieldContentRef, (event) => {
                                         colIndexOf(col, cIdx)
                                     )
                             "
-                            @start="
-                                () => {
-                                    isDraggingField = true;
-                                    draggingFromRow = rowIndexOf(row, rIdx);
-                                }
-                            "
-                            @end="
-                                () => {
-                                    isDraggingField = false;
-                                    draggingFromRow = null;
-                                }
-                            "
+                            @start="isDraggingField = true"
+                            @end="isDraggingField = false"
                         >
                             <template #item="{ element: field }">
                                 <FieldCard :field="field" :isDraggingAnyField="isDraggingField" />
@@ -270,10 +258,7 @@ onClickOutside(fieldContentRef, (event) => {
                     />
                 </div>
                 <RowDropZone
-                    v-show="
-                        rIdx === groupedRows.length - 1 &&
-                        draggingFromRow !== rowIndexOf(row, rIdx)
-                    "
+                    v-show="rIdx === groupedRows.length - 1"
                     :atRow="rowIndexOf(row, rIdx) + 1"
                     :isDragging="isDraggingField"
                     @drop="onRowZoneDrop"

--- a/frontend/src/components/FormBuilderContent.vue
+++ b/frontend/src/components/FormBuilderContent.vue
@@ -17,6 +17,18 @@ const fieldContentRef = ref<HTMLElement | null>(null);
 const isDraggingField = ref(false);
 const draggingFromRow = ref<number | null>(null);
 
+function resetDragState() {
+    isDraggingField.value = false;
+    draggingFromRow.value = null;
+}
+
+useEventListener(document, "pointerup", () => {
+    if (isDraggingField.value) resetDragState();
+});
+useEventListener(document, "dragend", () => {
+    if (isDraggingField.value) resetDragState();
+});
+
 const groupedRows = useGroupedRows(computed(() => editFormStore.fields));
 
 function fieldKey(field: FormField): string {
@@ -51,16 +63,19 @@ function onCellChange(evt: any, rowIndex: number, colIndex: number) {
     } else if (evt.added) {
         // Field dropped into this column from elsewhere — stack into column at cell index
         editFormStore.insertCell(evt.added.element, rowIndex, colIndex, evt.added.newIndex);
+        resetDragState();
     }
     // evt.removed: no-op — target column's evt.added owns the move
 }
 
 function onColumnZoneDrop(field: FormField, atRow: number, atCol: number) {
     editFormStore.moveField(field, atRow, atCol);
+    resetDragState();
 }
 
 function onRowZoneDrop(field: FormField, atRow: number) {
     editFormStore.insertNewRow(field, atRow);
+    resetDragState();
 }
 
 // Function to check if an element is a dropdown/popover (including portals)
@@ -211,7 +226,7 @@ onClickOutside(fieldContentRef, (event) => {
                             handle=".handle"
                             ghost-class="opacity-50"
                             tag="div"
-                            class="flex flex-col gap-2 flex-1 min-w-0"
+                            class="flex flex-col gap-4 flex-1 min-w-0"
                             @change="
                                 (evt: any) =>
                                     onCellChange(
@@ -246,7 +261,7 @@ onClickOutside(fieldContentRef, (event) => {
                     />
                 </div>
                 <RowDropZone
-                    v-if="
+                    v-show="
                         rIdx === groupedRows.length - 1 &&
                         draggingFromRow !== rowIndexOf(row, rIdx)
                     "

--- a/frontend/src/components/FormBuilderContent.vue
+++ b/frontend/src/components/FormBuilderContent.vue
@@ -8,6 +8,7 @@ import { useEditForm } from "@/stores/editForm";
 import { useGroupedRows } from "@/composables/useGroupedRows";
 import type { FormField } from "@/types/formfield";
 import FieldCard from "@/components/builder/FieldCard.vue";
+import RowDropZone from "@/components/builder/RowDropZone.vue";
 
 const editFormStore = useEditForm();
 
@@ -20,6 +21,10 @@ function fieldKey(field: FormField): string {
     return `${field.row_index ?? 0}-${field.column_index ?? 0}`;
 }
 
+function rowIndexOf(row: FormField[], rIdx: number): number {
+    return row[0]?.row_index ?? rIdx;
+}
+
 function onFieldChange(evt: any, rowIndex: number) {
     if (evt.moved) {
         // Reorder within the same row: renumber column_index based on new position
@@ -28,7 +33,8 @@ function onFieldChange(evt: any, rowIndex: number) {
             .filter((f: FormField) => (f.row_index ?? 0) === rowIndex)
             .sort((a: FormField, b: FormField) => (a.column_index ?? 0) - (b.column_index ?? 0));
         const oldIdx = rowFields.indexOf(element);
-        if (oldIdx !== -1) rowFields.splice(oldIdx, 1);
+        if (oldIdx === -1) return;
+        rowFields.splice(oldIdx, 1);
         rowFields.splice(newIndex, 0, element);
         rowFields.forEach((f: FormField, i: number) => {
             f.column_index = i;
@@ -38,6 +44,10 @@ function onFieldChange(evt: any, rowIndex: number) {
         editFormStore.moveField(evt.added.element, rowIndex, evt.added.newIndex);
     }
     // evt.removed: no-op — the target row's evt.added owns the move
+}
+
+function onRowZoneDrop(field: FormField, atRow: number) {
+    editFormStore.insertNewRow(field, atRow);
 }
 
 // Function to check if an element is a dropdown/popover (including portals)
@@ -164,11 +174,13 @@ onClickOutside(fieldContentRef, (event) => {
             </div>
         </div>
         <div class="flex flex-col gap-3">
-            <div
-                v-for="(row, rIdx) in groupedRows"
-                :key="row[0]?.row_index ?? rIdx"
-                class="flex flex-row gap-2 items-stretch"
-            >
+            <template v-for="(row, rIdx) in groupedRows" :key="rowIndexOf(row, rIdx)">
+                <RowDropZone
+                    v-if="rIdx > 0"
+                    :atRow="rowIndexOf(row, rIdx)"
+                    :isDragging="isDraggingField"
+                    @drop="onRowZoneDrop"
+                />
                 <draggableComponent
                     :list="[...row]"
                     :group="{ name: 'fields' }"
@@ -176,8 +188,8 @@ onClickOutside(fieldContentRef, (event) => {
                     handle=".handle"
                     ghost-class="opacity-50"
                     tag="div"
-                    class="flex flex-row gap-2 items-stretch flex-1 min-w-0"
-                    @change="(evt: any) => onFieldChange(evt, row[0]?.row_index ?? rIdx)"
+                    class="flex flex-row gap-2 items-stretch"
+                    @change="(evt: any) => onFieldChange(evt, rowIndexOf(row, rIdx))"
                     @start="isDraggingField = true"
                     @end="isDraggingField = false"
                 >
@@ -185,7 +197,7 @@ onClickOutside(fieldContentRef, (event) => {
                         <FieldCard :field="field" :isDraggingAnyField="isDraggingField" />
                     </template>
                 </draggableComponent>
-            </div>
+            </template>
         </div>
     </div>
 </template>

--- a/frontend/src/components/FormBuilderContent.vue
+++ b/frontend/src/components/FormBuilderContent.vue
@@ -2,9 +2,11 @@
 import { computed, ref } from "vue";
 import { LoadingIndicator, TextEditor } from "frappe-ui";
 import { onClickOutside, useEventListener } from "@vueuse/core";
+import draggableComponent from "vuedraggable";
 
 import { useEditForm } from "@/stores/editForm";
 import { useGroupedRows } from "@/composables/useGroupedRows";
+import type { FormField } from "@/types/formfield";
 import FieldCard from "@/components/builder/FieldCard.vue";
 
 const editFormStore = useEditForm();
@@ -13,6 +15,30 @@ const fieldContentRef = ref<HTMLElement | null>(null);
 const isDraggingField = ref(false);
 
 const groupedRows = useGroupedRows(computed(() => editFormStore.fields));
+
+function fieldKey(field: FormField): string {
+    return `${field.row_index ?? 0}-${field.column_index ?? 0}`;
+}
+
+function onFieldChange(evt: any, rowIndex: number) {
+    if (evt.moved) {
+        // Reorder within the same row: renumber column_index based on new position
+        const { element, newIndex } = evt.moved;
+        const rowFields: FormField[] = editFormStore.fields
+            .filter((f: FormField) => (f.row_index ?? 0) === rowIndex)
+            .sort((a: FormField, b: FormField) => (a.column_index ?? 0) - (b.column_index ?? 0));
+        const oldIdx = rowFields.indexOf(element);
+        if (oldIdx !== -1) rowFields.splice(oldIdx, 1);
+        rowFields.splice(newIndex, 0, element);
+        rowFields.forEach((f: FormField, i: number) => {
+            f.column_index = i;
+        });
+    } else if (evt.added) {
+        // Field dropped from another row — move it here at the given column
+        editFormStore.moveField(evt.added.element, rowIndex, evt.added.newIndex);
+    }
+    // evt.removed: no-op — the target row's evt.added owns the move
+}
 
 // Function to check if an element is a dropdown/popover (including portals)
 const isDropdownOrPopover = (element: Element | null): boolean => {
@@ -143,12 +169,22 @@ onClickOutside(fieldContentRef, (event) => {
                 :key="row[0]?.row_index ?? rIdx"
                 class="flex flex-row gap-2 items-stretch"
             >
-                <FieldCard
-                    v-for="field in row"
-                    :key="`${field.row_index}-${field.column_index}`"
-                    :field="field"
-                    :isDraggingAnyField="isDraggingField"
-                />
+                <draggableComponent
+                    :list="[...row]"
+                    :group="{ name: 'fields' }"
+                    :item-key="fieldKey"
+                    handle=".handle"
+                    ghost-class="opacity-50"
+                    tag="div"
+                    class="flex flex-row gap-2 items-stretch flex-1 min-w-0"
+                    @change="(evt: any) => onFieldChange(evt, row[0]?.row_index ?? rIdx)"
+                    @start="isDraggingField = true"
+                    @end="isDraggingField = false"
+                >
+                    <template #item="{ element: field }">
+                        <FieldCard :field="field" :isDraggingAnyField="isDraggingField" />
+                    </template>
+                </draggableComponent>
             </div>
         </div>
     </div>

--- a/frontend/src/components/FormBuilderContent.vue
+++ b/frontend/src/components/FormBuilderContent.vue
@@ -201,14 +201,14 @@ onClickOutside(fieldContentRef, (event) => {
                 <p class="text-base">Click on fields to add them to the form.</p>
             </div>
         </div>
-        <div class="flex flex-col gap-3">
+        <div class="flex flex-col">
             <template v-for="(row, rIdx) in groupedRows" :key="rowIndexOf(row, rIdx)">
                 <RowDropZone
                     :atRow="rowIndexOf(row, rIdx)"
                     :isDragging="isDraggingField"
                     @drop="onRowZoneDrop"
                 />
-                <div class="flex flex-row gap-2 items-stretch">
+                <div class="flex flex-row items-stretch">
                     <template
                         v-for="(col, cIdx) in row"
                         :key="`${rowIndexOf(row, rIdx)}-${colIndexOf(col, cIdx)}`"

--- a/frontend/src/components/FormBuilderContent.vue
+++ b/frontend/src/components/FormBuilderContent.vue
@@ -1,28 +1,25 @@
 <script setup lang="ts">
-import draggableComponent from "vuedraggable";
+import { computed, ref } from "vue";
 import { LoadingIndicator, TextEditor } from "frappe-ui";
-import { useEditForm } from "@/stores/editForm";
-import { FormField } from "@/types/formfield";
-import { ref } from "vue";
 import { onClickOutside, useEventListener } from "@vueuse/core";
 
-import FieldRenderer from "@/components/builder/FieldRenderer.vue";
-import FieldActions from "@/components/builder/FieldActions.vue";
+import { useEditForm } from "@/stores/editForm";
+import { useGroupedRows } from "@/composables/useGroupedRows";
+import FieldCard from "@/components/builder/FieldCard.vue";
 
 const editFormStore = useEditForm();
 
-// Ref for the entire FormBuilderContent component
 const fieldContentRef = ref<HTMLElement | null>(null);
 const isDraggingField = ref(false);
+
+const groupedRows = useGroupedRows(computed(() => editFormStore.fields));
 
 // Function to check if an element is a dropdown/popover (including portals)
 const isDropdownOrPopover = (element: Element | null): boolean => {
     if (!element) return false;
 
-    // Walk up the DOM tree to check for dropdown indicators
     let current: Element | null = element;
     while (current && current !== document.body) {
-        // Check for Headless UI patterns
         if (
             current.hasAttribute("role") &&
             (current.getAttribute("role") === "listbox" ||
@@ -32,12 +29,10 @@ const isDropdownOrPopover = (element: Element | null): boolean => {
             return true;
         }
 
-        // Check for Headless UI data attributes
         if (current.hasAttribute("data-headlessui-state") || current.id?.includes("headlessui")) {
             return true;
         }
 
-        // Check for Radix UI patterns
         if (
             current.hasAttribute("data-radix-popper-content-wrapper") ||
             current.id?.startsWith("radix") ||
@@ -46,7 +41,6 @@ const isDropdownOrPopover = (element: Element | null): boolean => {
             return true;
         }
 
-        // Check for common dropdown classes
         const classList = current.classList;
         if (
             classList.contains("dropdown-menu") ||
@@ -70,9 +64,7 @@ useEventListener("keydown", (event: KeyboardEvent) => {
     }
 });
 
-// Set up outside click detection for the entire FormBuilderContent component
 onClickOutside(fieldContentRef, (event) => {
-    // Check if the click is on any other form builder components
     const target = event.target as Element;
     const isFormBuilderComponent =
         target.closest("[data-form-builder-component]") ||
@@ -80,12 +72,8 @@ onClickOutside(fieldContentRef, (event) => {
         target.closest(".form-builder-sidebar") ||
         target.closest(".form-builder-header");
 
-    // Check if the click is on a dropdown menu (which may be rendered in a portal)
-    // This handles Headless UI, Radix UI, and other common dropdown patterns
     const isDropdownElement = isDropdownOrPopover(target);
 
-    // Also check if there are any visible/open dropdowns in the DOM
-    // This catches dropdowns that might be open but the click target isn't directly on them
     const hasOpenDropdown = !!(
         document.querySelector('[role="listbox"]:not([hidden]):not([style*="display: none"])') ||
         document.querySelector('[role="combobox"][aria-expanded="true"]') ||
@@ -93,8 +81,6 @@ onClickOutside(fieldContentRef, (event) => {
         document.querySelector('[aria-expanded="true"][role="combobox"]')
     );
 
-    // Check if the active element (focused element) is within the sidebar
-    // This helps catch cases where a dropdown is open and the user is interacting with it
     const activeElement = document.activeElement;
     const isActiveElementInSidebar = activeElement
         ? !!(
@@ -104,8 +90,6 @@ onClickOutside(fieldContentRef, (event) => {
           )
         : false;
 
-    // Only deselect if NOT clicking on other form builder components or dropdowns
-    // Also don't deselect if there's an open dropdown or if the active element is in the sidebar
     if (
         !isFormBuilderComponent &&
         !isDropdownElement &&
@@ -116,6 +100,7 @@ onClickOutside(fieldContentRef, (event) => {
     }
 });
 </script>
+
 <template>
     <div v-if="editFormStore.isLoading">
         <LoadingIndicator />
@@ -152,37 +137,19 @@ onClickOutside(fieldContentRef, (event) => {
                 <p class="text-base">Click on fields to add them to the form.</p>
             </div>
         </div>
-        <div>
-            <draggableComponent
-                :list="editFormStore.fields"
-                item-key="idx"
-                tag="div"
-                handle=".handle"
-                ghost-class="opacity-50"
-                @start="isDraggingField = true"
-                @end="isDraggingField = false"
+        <div class="flex flex-col gap-2">
+            <div
+                v-for="(row, rIdx) in groupedRows"
+                :key="rIdx"
+                class="flex flex-row gap-2 items-stretch"
             >
-                <template #item="{ element }">
-                    <div
-                        @click="editFormStore.selectField(element)"
-                        class="my-3 relative transition-colors group"
-                    >
-                        <FieldActions
-                            :isSelected="editFormStore.selectedField === element"
-                            :isDraggingAnyField="isDraggingField"
-                            @remove="editFormStore.removeField(element)"
-                        />
-                        <FieldRenderer
-                            :field="element"
-                            @update:field="
-                                (updatedField: FormField) =>
-                                    editFormStore.updateField(element, updatedField)
-                            "
-                            :inEditMode="true"
-                        />
-                    </div>
-                </template>
-            </draggableComponent>
+                <FieldCard
+                    v-for="field in row"
+                    :key="field.idx"
+                    :field="field"
+                    :isDraggingAnyField="isDraggingField"
+                />
+            </div>
         </div>
     </div>
 </template>

--- a/frontend/src/components/FormBuilderContent.vue
+++ b/frontend/src/components/FormBuilderContent.vue
@@ -9,6 +9,7 @@ import { useGroupedRows } from "@/composables/useGroupedRows";
 import type { FormField } from "@/types/formfield";
 import FieldCard from "@/components/builder/FieldCard.vue";
 import RowDropZone from "@/components/builder/RowDropZone.vue";
+import ColumnDropZone from "@/components/builder/ColumnDropZone.vue";
 
 const editFormStore = useEditForm();
 
@@ -19,32 +20,43 @@ const draggingFromRow = ref<number | null>(null);
 const groupedRows = useGroupedRows(computed(() => editFormStore.fields));
 
 function fieldKey(field: FormField): string {
-    return `${field.row_index ?? 0}-${field.column_index ?? 0}`;
+    return `${field.row_index ?? 0}-${field.column_index ?? 0}-${field.cell_index ?? 0}`;
 }
 
-function rowIndexOf(row: FormField[], rIdx: number): number {
-    return row[0]?.row_index ?? rIdx;
+function rowIndexOf(row: FormField[][], rIdx: number): number {
+    return row[0]?.[0]?.row_index ?? rIdx;
 }
 
-function onFieldChange(evt: any, rowIndex: number) {
+function colIndexOf(col: FormField[], cIdx: number): number {
+    return col[0]?.column_index ?? cIdx;
+}
+
+function onCellChange(evt: any, rowIndex: number, colIndex: number) {
     if (evt.moved) {
-        // Reorder within the same row: renumber column_index based on new position
+        // Reorder cells within same column: renumber cell_index by new position
         const { element, newIndex } = evt.moved;
-        const rowFields: FormField[] = editFormStore.fields
-            .filter((f: FormField) => (f.row_index ?? 0) === rowIndex)
-            .sort((a: FormField, b: FormField) => (a.column_index ?? 0) - (b.column_index ?? 0));
-        const oldIdx = rowFields.indexOf(element);
+        const cells: FormField[] = editFormStore.fields
+            .filter(
+                (f: FormField) =>
+                    (f.row_index ?? 0) === rowIndex && (f.column_index ?? 0) === colIndex
+            )
+            .sort((a: FormField, b: FormField) => (a.cell_index ?? 0) - (b.cell_index ?? 0));
+        const oldIdx = cells.indexOf(element);
         if (oldIdx === -1) return;
-        rowFields.splice(oldIdx, 1);
-        rowFields.splice(newIndex, 0, element);
-        rowFields.forEach((f: FormField, i: number) => {
-            f.column_index = i;
+        cells.splice(oldIdx, 1);
+        cells.splice(newIndex, 0, element);
+        cells.forEach((f: FormField, i: number) => {
+            f.cell_index = i;
         });
     } else if (evt.added) {
-        // Field dropped from another row — move it here at the given column
-        editFormStore.moveField(evt.added.element, rowIndex, evt.added.newIndex);
+        // Field dropped into this column from elsewhere — stack into column at cell index
+        editFormStore.insertCell(evt.added.element, rowIndex, colIndex, evt.added.newIndex);
     }
-    // evt.removed: no-op — the target row's evt.added owns the move
+    // evt.removed: no-op — target column's evt.added owns the move
+}
+
+function onColumnZoneDrop(field: FormField, atRow: number, atCol: number) {
+    editFormStore.moveField(field, atRow, atCol);
 }
 
 function onRowZoneDrop(field: FormField, atRow: number) {
@@ -181,32 +193,58 @@ onClickOutside(fieldContentRef, (event) => {
                     :isDragging="isDraggingField"
                     @drop="onRowZoneDrop"
                 />
-                <draggableComponent
-                    :list="[...row]"
-                    :group="{ name: 'fields' }"
-                    :item-key="fieldKey"
-                    handle=".handle"
-                    ghost-class="opacity-50"
-                    tag="div"
-                    class="flex flex-row gap-2 items-stretch"
-                    @change="(evt: any) => onFieldChange(evt, rowIndexOf(row, rIdx))"
-                    @start="
-                        () => {
-                            isDraggingField = true;
-                            draggingFromRow = rowIndexOf(row, rIdx);
-                        }
-                    "
-                    @end="
-                        () => {
-                            isDraggingField = false;
-                            draggingFromRow = null;
-                        }
-                    "
-                >
-                    <template #item="{ element: field }">
-                        <FieldCard :field="field" :isDraggingAnyField="isDraggingField" />
+                <div class="flex flex-row gap-2 items-stretch">
+                    <template
+                        v-for="(col, cIdx) in row"
+                        :key="`${rowIndexOf(row, rIdx)}-${colIndexOf(col, cIdx)}`"
+                    >
+                        <ColumnDropZone
+                            :atRow="rowIndexOf(row, rIdx)"
+                            :atCol="colIndexOf(col, cIdx)"
+                            :isDragging="isDraggingField"
+                            @drop="onColumnZoneDrop"
+                        />
+                        <draggableComponent
+                            :list="[...col]"
+                            :group="{ name: 'fields' }"
+                            :item-key="fieldKey"
+                            handle=".handle"
+                            ghost-class="opacity-50"
+                            tag="div"
+                            class="flex flex-col gap-2 flex-1 min-w-0"
+                            @change="
+                                (evt: any) =>
+                                    onCellChange(
+                                        evt,
+                                        rowIndexOf(row, rIdx),
+                                        colIndexOf(col, cIdx)
+                                    )
+                            "
+                            @start="
+                                () => {
+                                    isDraggingField = true;
+                                    draggingFromRow = rowIndexOf(row, rIdx);
+                                }
+                            "
+                            @end="
+                                () => {
+                                    isDraggingField = false;
+                                    draggingFromRow = null;
+                                }
+                            "
+                        >
+                            <template #item="{ element: field }">
+                                <FieldCard :field="field" :isDraggingAnyField="isDraggingField" />
+                            </template>
+                        </draggableComponent>
                     </template>
-                </draggableComponent>
+                    <ColumnDropZone
+                        :atRow="rowIndexOf(row, rIdx)"
+                        :atCol="row.length"
+                        :isDragging="isDraggingField"
+                        @drop="onColumnZoneDrop"
+                    />
+                </div>
                 <RowDropZone
                     v-if="
                         rIdx === groupedRows.length - 1 &&

--- a/frontend/src/components/FormBuilderContent.vue
+++ b/frontend/src/components/FormBuilderContent.vue
@@ -208,7 +208,11 @@ onClickOutside(fieldContentRef, (event) => {
                     :isDragging="isDraggingField"
                     @drop="onRowZoneDrop"
                 />
-                <div class="flex flex-row items-stretch">
+                <div
+                    class="flex flex-row items-stretch"
+                    data-form-builder-component="form-row"
+                    :data-row-index="rowIndexOf(row, rIdx)"
+                >
                     <template
                         v-for="(col, cIdx) in row"
                         :key="`${rowIndexOf(row, rIdx)}-${colIndexOf(col, cIdx)}`"
@@ -227,6 +231,10 @@ onClickOutside(fieldContentRef, (event) => {
                             handle=".handle"
                             ghost-class="opacity-50"
                             tag="div"
+                            :force-fallback="true"
+                            data-form-builder-component="cell-column"
+                            :data-row-index="rowIndexOf(row, rIdx)"
+                            :data-col-index="colIndexOf(col, cIdx)"
                             class="flex flex-col gap-4 flex-1 min-w-0"
                             @change="
                                 (evt: any) =>

--- a/frontend/src/components/FormBuilderContent.vue
+++ b/frontend/src/components/FormBuilderContent.vue
@@ -223,6 +223,7 @@ onClickOutside(fieldContentRef, (event) => {
                             :list="[...col]"
                             :group="{ name: 'fields' }"
                             :item-key="fieldKey"
+                            :animation="150"
                             handle=".handle"
                             ghost-class="opacity-50"
                             tag="div"

--- a/frontend/src/components/FormBuilderContent.vue
+++ b/frontend/src/components/FormBuilderContent.vue
@@ -137,15 +137,15 @@ onClickOutside(fieldContentRef, (event) => {
                 <p class="text-base">Click on fields to add them to the form.</p>
             </div>
         </div>
-        <div class="flex flex-col gap-2">
+        <div class="flex flex-col gap-3">
             <div
                 v-for="(row, rIdx) in groupedRows"
-                :key="rIdx"
+                :key="row[0]?.row_index ?? rIdx"
                 class="flex flex-row gap-2 items-stretch"
             >
                 <FieldCard
                     v-for="field in row"
-                    :key="field.idx"
+                    :key="`${field.row_index}-${field.column_index}`"
                     :field="field"
                     :isDraggingAnyField="isDraggingField"
                 />

--- a/frontend/src/components/builder/ColumnDropZone.vue
+++ b/frontend/src/components/builder/ColumnDropZone.vue
@@ -52,9 +52,9 @@ async function onZoneChange(evt: any) {
         :class="[
             'transition-all duration-150 self-stretch',
             isHighlighted
-                ? 'border-2 border-dashed border-blue-400 bg-blue-50 w-3'
+                ? 'bg-surface-blue-3 w-1'
                 : isDragging
-                ? 'border border-dashed border-gray-200 w-px'
+                ? 'bg-surface-blue-1 w-1'
                 : 'bg-transparent w-px',
         ]"
         @change="onZoneChange"

--- a/frontend/src/components/builder/ColumnDropZone.vue
+++ b/frontend/src/components/builder/ColumnDropZone.vue
@@ -51,7 +51,7 @@ async function onZoneChange(evt: any) {
         tag="div"
         :class="[
             'relative w-4 self-stretch',
-            'before:content-[\'\'] before:absolute before:inset-y-0 before:left-1/2 before:-translate-x-1/2 before:rounded-full before:transition-all before:duration-150',
+            'before:content-[\'\'] before:absolute before:inset-y-0 before:left-1/2 before:-translate-x-1/2 before:rounded-full before:transition-[width,background-color] before:duration-150 before:ease-out motion-reduce:before:transition-none',
             isHighlighted
                 ? 'before:w-1 before:bg-surface-blue-3'
                 : isDragging

--- a/frontend/src/components/builder/ColumnDropZone.vue
+++ b/frontend/src/components/builder/ColumnDropZone.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import draggableComponent from "vuedraggable";
+import type { FormField } from "@/types/formfield";
+import { ref, computed, onMounted, onUnmounted, nextTick } from "vue";
+
+const props = defineProps<{
+    atRow: number;
+    atCol: number;
+    isDragging: boolean;
+}>();
+
+const emit = defineEmits<{
+    drop: [field: FormField, atRow: number, atCol: number];
+}>();
+
+const buffer = ref<FormField[]>([]);
+const draggableRef = ref<any>(null);
+const isOver = ref(false);
+let observer: MutationObserver | null = null;
+
+onMounted(() => {
+    const el = draggableRef.value?.$el;
+    if (!el) return;
+    observer = new MutationObserver(() => {
+        isOver.value = el.children.length > 0;
+    });
+    observer.observe(el, { childList: true });
+});
+
+onUnmounted(() => {
+    observer?.disconnect();
+});
+
+const isHighlighted = computed(() => props.isDragging && isOver.value);
+
+async function onZoneChange(evt: any) {
+    if (evt.added) {
+        emit("drop", evt.added.element, props.atRow, props.atCol);
+        await nextTick();
+        buffer.value = [];
+    }
+}
+</script>
+
+<template>
+    <draggableComponent
+        ref="draggableRef"
+        :list="buffer"
+        :group="{ name: 'fields', put: true, pull: false }"
+        item-key="fieldname"
+        tag="div"
+        :class="[
+            'transition-all duration-150 self-stretch',
+            isHighlighted
+                ? 'border-2 border-dashed border-blue-400 bg-blue-50 w-3'
+                : isDragging
+                ? 'border border-dashed border-gray-200 w-px'
+                : 'bg-transparent w-px',
+        ]"
+        @change="onZoneChange"
+    >
+        <template #item="{}"></template>
+    </draggableComponent>
+</template>

--- a/frontend/src/components/builder/ColumnDropZone.vue
+++ b/frontend/src/components/builder/ColumnDropZone.vue
@@ -50,12 +50,13 @@ async function onZoneChange(evt: any) {
         item-key="fieldname"
         tag="div"
         :class="[
-            'transition-all duration-150 self-stretch',
+            'relative w-4 self-stretch',
+            'before:content-[\'\'] before:absolute before:inset-y-0 before:left-1/2 before:-translate-x-1/2 before:rounded-full before:transition-all before:duration-150',
             isHighlighted
-                ? 'bg-surface-blue-3 w-1'
+                ? 'before:w-1 before:bg-surface-blue-3'
                 : isDragging
-                ? 'bg-surface-blue-1 w-1'
-                : 'bg-transparent w-px',
+                ? 'before:w-px before:bg-surface-blue-1'
+                : 'before:w-0 before:bg-transparent',
         ]"
         @change="onZoneChange"
     >

--- a/frontend/src/components/builder/ColumnDropZone.vue
+++ b/frontend/src/components/builder/ColumnDropZone.vue
@@ -49,6 +49,10 @@ async function onZoneChange(evt: any) {
         :group="{ name: 'fields', put: true, pull: false }"
         item-key="fieldname"
         tag="div"
+        :force-fallback="true"
+        data-form-builder-component="column-drop-zone"
+        :data-at-row="props.atRow"
+        :data-at-col="props.atCol"
         :class="[
             'relative w-4 self-stretch',
             'before:content-[\'\'] before:absolute before:inset-y-0 before:left-1/2 before:-translate-x-1/2 before:rounded-full before:transition-[width,background-color] before:duration-150 before:ease-out motion-reduce:before:transition-none',

--- a/frontend/src/components/builder/FieldActions.vue
+++ b/frontend/src/components/builder/FieldActions.vue
@@ -5,7 +5,7 @@ import { Button } from "frappe-ui";
 defineProps<{
     isSelected: boolean;
     isDraggingAnyField: boolean;
-    isMultiColumn: boolean;
+    canEject: boolean;
 }>();
 
 defineEmits<{
@@ -25,7 +25,7 @@ defineEmits<{
         ]"
     >
         <Button
-            v-if="isMultiColumn"
+            v-if="canEject"
             size="sm"
             :icon="SquareSplitVertical"
             variant="ghost"

--- a/frontend/src/components/builder/FieldActions.vue
+++ b/frontend/src/components/builder/FieldActions.vue
@@ -31,6 +31,7 @@ defineEmits<{
             variant="ghost"
             @click.stop="$emit('eject')"
             tooltip="Move to own row"
+            data-form-builder-component="eject-button"
         />
         <Button
             size="sm"

--- a/frontend/src/components/builder/FieldActions.vue
+++ b/frontend/src/components/builder/FieldActions.vue
@@ -1,14 +1,16 @@
 <script setup lang="ts">
-import { GripVertical, Trash2 } from "@lucide/vue";
+import { GripVertical, SquareSplitVertical, Trash2 } from "@lucide/vue";
 import { Button } from "frappe-ui";
 
 defineProps<{
     isSelected: boolean;
     isDraggingAnyField: boolean;
+    isMultiColumn: boolean;
 }>();
 
 defineEmits<{
     (e: "remove"): void;
+    (e: "eject"): void;
 }>();
 </script>
 <template>
@@ -22,6 +24,14 @@ defineEmits<{
                 : 'opacity-0 scale-90 group-hover:opacity-100 group-hover:scale-100',
         ]"
     >
+        <Button
+            v-if="isMultiColumn"
+            size="sm"
+            :icon="SquareSplitVertical"
+            variant="ghost"
+            @click.stop="$emit('eject')"
+            tooltip="Move to own row"
+        />
         <Button
             size="sm"
             :icon="Trash2"

--- a/frontend/src/components/builder/FieldCard.vue
+++ b/frontend/src/components/builder/FieldCard.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import type { FormField } from "@/types/formfield";
 import { useEditForm } from "@/stores/editForm";
 import FieldActions from "@/components/builder/FieldActions.vue";
@@ -10,6 +11,17 @@ const props = defineProps<{
 }>();
 
 const editFormStore = useEditForm();
+
+const isMultiColumn = computed(
+    () =>
+        editFormStore.fields.filter(
+            (f: FormField) => (f.row_index ?? 0) === (props.field.row_index ?? 0)
+        ).length > 1
+);
+
+function ejectToOwnRow() {
+    editFormStore.insertNewRow(props.field, (props.field.row_index ?? 0) + 1);
+}
 </script>
 
 <template>
@@ -20,7 +32,9 @@ const editFormStore = useEditForm();
         <FieldActions
             :isSelected="editFormStore.selectedField === props.field"
             :isDraggingAnyField="props.isDraggingAnyField"
+            :isMultiColumn="isMultiColumn"
             @remove="editFormStore.removeField(props.field)"
+            @eject="ejectToOwnRow"
         />
         <FieldRenderer
             :field="props.field"

--- a/frontend/src/components/builder/FieldCard.vue
+++ b/frontend/src/components/builder/FieldCard.vue
@@ -27,6 +27,12 @@ function ejectToOwnRow() {
 <template>
     <div
         class="relative flex-1 min-w-0 transition-colors group"
+        data-form-builder-component="field-card"
+        :data-field-label="props.field.label ?? ''"
+        :data-field-name="props.field.fieldname ?? ''"
+        :data-row-index="props.field.row_index ?? 0"
+        :data-col-index="props.field.column_index ?? 0"
+        :data-cell-index="props.field.cell_index ?? 0"
         @click="editFormStore.selectField(props.field)"
     >
         <FieldActions

--- a/frontend/src/components/builder/FieldCard.vue
+++ b/frontend/src/components/builder/FieldCard.vue
@@ -12,7 +12,11 @@ const props = defineProps<{
 
 const editFormStore = useEditForm();
 
-const isMultiColumn = computed(
+// Eject = "Move to own row". Available whenever the row holds more than one
+// cell — that is, more than one column OR more than one stacked cell within
+// a single column. (Variable was previously named `isMultiColumn`, which
+// understated the stacked-cell case.)
+const canEject = computed(
     () =>
         editFormStore.fields.filter(
             (f: FormField) => (f.row_index ?? 0) === (props.field.row_index ?? 0)
@@ -38,7 +42,7 @@ function ejectToOwnRow() {
         <FieldActions
             :isSelected="editFormStore.selectedField === props.field"
             :isDraggingAnyField="props.isDraggingAnyField"
-            :isMultiColumn="isMultiColumn"
+            :canEject="canEject"
             @remove="editFormStore.removeField(props.field)"
             @eject="ejectToOwnRow"
         />

--- a/frontend/src/components/builder/FieldCard.vue
+++ b/frontend/src/components/builder/FieldCard.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import type { FormField } from "@/types/formfield";
+import { useEditForm } from "@/stores/editForm";
+import FieldActions from "@/components/builder/FieldActions.vue";
+import FieldRenderer from "@/components/builder/FieldRenderer.vue";
+
+const props = defineProps<{
+    field: FormField;
+    isDraggingAnyField: boolean;
+}>();
+
+const editFormStore = useEditForm();
+</script>
+
+<template>
+    <div
+        class="relative flex-1 min-w-0 transition-colors group"
+        @click="editFormStore.selectField(props.field)"
+    >
+        <FieldActions
+            :isSelected="editFormStore.selectedField === props.field"
+            :isDraggingAnyField="props.isDraggingAnyField"
+            @remove="editFormStore.removeField(props.field)"
+        />
+        <FieldRenderer
+            :field="props.field"
+            :inEditMode="true"
+            @update:field="
+                (updated: FormField) => editFormStore.updateField(props.field, updated)
+            "
+        />
+    </div>
+</template>

--- a/frontend/src/components/builder/RowDropZone.vue
+++ b/frontend/src/components/builder/RowDropZone.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import draggableComponent from "vuedraggable";
 import type { FormField } from "@/types/formfield";
-import { ref, nextTick } from "vue";
+import { ref, computed, onMounted, onUnmounted, nextTick } from "vue";
 
 const props = defineProps<{
     atRow: number;
@@ -13,6 +13,26 @@ const emit = defineEmits<{
 }>();
 
 const buffer = ref<FormField[]>([]);
+const draggableRef = ref<any>(null);
+const isOver = ref(false);
+let observer: MutationObserver | null = null;
+
+// SortableJS inserts a placeholder child into the target list while hovering.
+// Watching for that insertion is more reliable than pointer events during drag.
+onMounted(() => {
+    const el = draggableRef.value?.$el;
+    if (!el) return;
+    observer = new MutationObserver(() => {
+        isOver.value = el.children.length > 0;
+    });
+    observer.observe(el, { childList: true });
+});
+
+onUnmounted(() => {
+    observer?.disconnect();
+});
+
+const isHighlighted = computed(() => props.isDragging && isOver.value);
 
 async function onZoneChange(evt: any) {
     if (evt.added) {
@@ -25,13 +45,18 @@ async function onZoneChange(evt: any) {
 
 <template>
     <draggableComponent
+        ref="draggableRef"
         :list="buffer"
         :group="{ name: 'fields', put: true, pull: false }"
         item-key="fieldname"
         tag="div"
         :class="[
-            'rounded transition-all duration-150',
-            isDragging ? 'h-6 border-2 border-dashed border-gray-300 bg-gray-50' : 'h-1',
+            'transition-all duration-150 h-px w-full',
+            isHighlighted
+                ? 'border-2 border-dashed border-blue-400 bg-blue-50'
+                : isDragging
+                ? 'border border-dashed border-gray-200'
+                : 'bg-transparent',
         ]"
         @change="onZoneChange"
     >

--- a/frontend/src/components/builder/RowDropZone.vue
+++ b/frontend/src/components/builder/RowDropZone.vue
@@ -52,7 +52,7 @@ async function onZoneChange(evt: any) {
         tag="div"
         :class="[
             'relative h-6 w-full',
-            'before:content-[\'\'] before:absolute before:inset-x-0 before:top-1/2 before:-translate-y-1/2 before:rounded-full before:transition-all before:duration-150',
+            'before:content-[\'\'] before:absolute before:inset-x-0 before:top-1/2 before:-translate-y-1/2 before:rounded-full before:transition-[height,background-color] before:duration-150 before:ease-out motion-reduce:before:transition-none',
             isHighlighted
                 ? 'before:h-1 before:bg-surface-blue-3'
                 : isDragging

--- a/frontend/src/components/builder/RowDropZone.vue
+++ b/frontend/src/components/builder/RowDropZone.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import draggableComponent from "vuedraggable";
+import type { FormField } from "@/types/formfield";
+import { ref, nextTick } from "vue";
+
+const props = defineProps<{
+    atRow: number;
+    isDragging: boolean;
+}>();
+
+const emit = defineEmits<{
+    drop: [field: FormField, atRow: number];
+}>();
+
+const buffer = ref<FormField[]>([]);
+
+async function onZoneChange(evt: any) {
+    if (evt.added) {
+        emit("drop", evt.added.element, props.atRow);
+        await nextTick();
+        buffer.value = [];
+    }
+}
+</script>
+
+<template>
+    <draggableComponent
+        :list="buffer"
+        :group="{ name: 'fields', put: true, pull: false }"
+        item-key="fieldname"
+        tag="div"
+        :class="[
+            'rounded transition-all duration-150',
+            isDragging ? 'h-6 border-2 border-dashed border-gray-300 bg-gray-50' : 'h-1',
+        ]"
+        @change="onZoneChange"
+    >
+        <template #item="{}"></template>
+    </draggableComponent>
+</template>

--- a/frontend/src/components/builder/RowDropZone.vue
+++ b/frontend/src/components/builder/RowDropZone.vue
@@ -51,12 +51,12 @@ async function onZoneChange(evt: any) {
         item-key="fieldname"
         tag="div"
         :class="[
-            'transition-all duration-150 h-px w-full',
+            'transition-all duration-150 w-full',
             isHighlighted
-                ? 'border-2 border-dashed border-blue-400 bg-blue-50'
+                ? 'bg-surface-blue-3 h-1'
                 : isDragging
-                ? 'border border-dashed border-gray-200'
-                : 'bg-transparent',
+                ? 'bg-surface-blue-1 h-1'
+                : 'bg-transparent h-px',
         ]"
         @change="onZoneChange"
     >

--- a/frontend/src/components/builder/RowDropZone.vue
+++ b/frontend/src/components/builder/RowDropZone.vue
@@ -51,12 +51,13 @@ async function onZoneChange(evt: any) {
         item-key="fieldname"
         tag="div"
         :class="[
-            'transition-all duration-150 w-full',
+            'relative h-6 w-full',
+            'before:content-[\'\'] before:absolute before:inset-x-0 before:top-1/2 before:-translate-y-1/2 before:rounded-full before:transition-all before:duration-150',
             isHighlighted
-                ? 'bg-surface-blue-3 h-1'
+                ? 'before:h-1 before:bg-surface-blue-3'
                 : isDragging
-                ? 'bg-surface-blue-1 h-1'
-                : 'bg-transparent h-px',
+                ? 'before:h-px before:bg-surface-blue-1'
+                : 'before:h-0 before:bg-transparent',
         ]"
         @change="onZoneChange"
     >

--- a/frontend/src/components/builder/RowDropZone.vue
+++ b/frontend/src/components/builder/RowDropZone.vue
@@ -50,6 +50,9 @@ async function onZoneChange(evt: any) {
         :group="{ name: 'fields', put: true, pull: false }"
         item-key="fieldname"
         tag="div"
+        :force-fallback="true"
+        data-form-builder-component="row-drop-zone"
+        :data-at-row="props.atRow"
         :class="[
             'relative h-6 w-full',
             'before:content-[\'\'] before:absolute before:inset-x-0 before:top-1/2 before:-translate-y-1/2 before:rounded-full before:transition-[height,background-color] before:duration-150 before:ease-out motion-reduce:before:transition-none',

--- a/frontend/src/components/submission/FormRenderer.vue
+++ b/frontend/src/components/submission/FormRenderer.vue
@@ -47,11 +47,13 @@ function handleSubmitForm() {
             <div
                 v-if="row.some((col) => col.some(isFieldVisible))"
                 class="flex flex-col md:flex-row gap-4"
+                data-form-renderer-component="form-row"
             >
                 <template v-for="(col, cIdx) in row" :key="colKey(col, cIdx)">
                     <div
                         v-if="col.some(isFieldVisible)"
                         class="flex flex-col gap-4 flex-1 min-w-0"
+                        data-form-renderer-component="form-column"
                     >
                         <template v-for="field in col" :key="field.fieldname">
                             <div v-if="isFieldVisible(field)">

--- a/frontend/src/components/submission/FormRenderer.vue
+++ b/frontend/src/components/submission/FormRenderer.vue
@@ -4,6 +4,7 @@ import { useSubmissionForm } from "@/stores/submissionForm";
 import FieldRenderer from "@/components/builder/FieldRenderer.vue";
 import { computed } from "vue";
 import { shouldFieldBeVisible, shouldFieldBeRequired } from "@/utils/conditionals";
+import { useGroupedRows } from "@/composables/useGroupedRows";
 import type { FormField } from "@/types/formfield";
 
 const submissionFormStore = useSubmissionForm();
@@ -17,14 +18,13 @@ const props = withDefaults(
     }
 );
 
-// Computed property to get visible fields based on conditional logic
-// This will automatically update when form values change
-const visibleFields = computed(() => {
-    const fields = submissionFormStore.formResource.data?.fields || [];
-    return fields.filter((field: FormField) =>
-        shouldFieldBeVisible(field, submissionFormStore.fields, fields)
-    );
-});
+const allFields = computed<FormField[]>(() => submissionFormStore.formResource.data?.fields || []);
+
+const groupedRows = useGroupedRows(allFields);
+
+function isFieldVisible(field: FormField) {
+    return shouldFieldBeVisible(field, submissionFormStore.fields, allFields.value);
+}
 
 function handleSubmitForm() {
     submissionFormStore.submitForm();
@@ -35,21 +35,27 @@ function handleSubmitForm() {
         <LoadingIndicator class="mx-auto my-auto w-5 h-5" />
     </div>
     <div v-if="submissionFormStore.inFormFillingState" class="flex flex-col gap-4">
-        <div v-for="field in visibleFields" :key="field.fieldname">
-            <FieldRenderer
-                :disabled="disabled"
-                v-model="submissionFormStore.fields[field.fieldname]"
-                :field="{
-                    ...field,
-                    reqd: shouldFieldBeRequired(
-                        field,
-                        submissionFormStore.fields,
-                        submissionFormStore.formResource.data?.fields || []
-                    ),
-                }"
-                :inEditMode="false"
-            />
-        </div>
+        <template v-for="(row, rIdx) in groupedRows" :key="`r-${row[0]?.row_index ?? rIdx}`">
+            <div v-if="row.some(isFieldVisible)" class="flex flex-col md:flex-row gap-4">
+                <template v-for="field in row" :key="field.fieldname">
+                    <div v-if="isFieldVisible(field)" class="flex-1 min-w-0">
+                        <FieldRenderer
+                            :disabled="disabled"
+                            v-model="submissionFormStore.fields[field.fieldname]"
+                            :field="{
+                                ...field,
+                                reqd: shouldFieldBeRequired(
+                                    field,
+                                    submissionFormStore.fields,
+                                    allFields
+                                ),
+                            }"
+                            :inEditMode="false"
+                        />
+                    </div>
+                </template>
+            </div>
+        </template>
         <hr />
         <ErrorMessage :message="submissionFormStore.errors.join('\n')" />
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4 w-full">

--- a/frontend/src/components/submission/FormRenderer.vue
+++ b/frontend/src/components/submission/FormRenderer.vue
@@ -26,6 +26,14 @@ function isFieldVisible(field: FormField) {
     return shouldFieldBeVisible(field, submissionFormStore.fields, allFields.value);
 }
 
+function rowKey(row: FormField[][], rIdx: number) {
+    return `r-${row[0]?.[0]?.row_index ?? rIdx}`;
+}
+
+function colKey(col: FormField[], cIdx: number) {
+    return `c-${col[0]?.column_index ?? cIdx}`;
+}
+
 function handleSubmitForm() {
     submissionFormStore.submitForm();
 }
@@ -35,23 +43,33 @@ function handleSubmitForm() {
         <LoadingIndicator class="mx-auto my-auto w-5 h-5" />
     </div>
     <div v-if="submissionFormStore.inFormFillingState" class="flex flex-col gap-4">
-        <template v-for="(row, rIdx) in groupedRows" :key="`r-${row[0]?.row_index ?? rIdx}`">
-            <div v-if="row.some(isFieldVisible)" class="flex flex-col md:flex-row gap-4">
-                <template v-for="field in row" :key="field.fieldname">
-                    <div v-if="isFieldVisible(field)" class="flex-1 min-w-0">
-                        <FieldRenderer
-                            :disabled="disabled"
-                            v-model="submissionFormStore.fields[field.fieldname]"
-                            :field="{
-                                ...field,
-                                reqd: shouldFieldBeRequired(
-                                    field,
-                                    submissionFormStore.fields,
-                                    allFields
-                                ),
-                            }"
-                            :inEditMode="false"
-                        />
+        <template v-for="(row, rIdx) in groupedRows" :key="rowKey(row, rIdx)">
+            <div
+                v-if="row.some((col) => col.some(isFieldVisible))"
+                class="flex flex-col md:flex-row gap-4"
+            >
+                <template v-for="(col, cIdx) in row" :key="colKey(col, cIdx)">
+                    <div
+                        v-if="col.some(isFieldVisible)"
+                        class="flex flex-col gap-4 flex-1 min-w-0"
+                    >
+                        <template v-for="field in col" :key="field.fieldname">
+                            <div v-if="isFieldVisible(field)">
+                                <FieldRenderer
+                                    :disabled="disabled"
+                                    v-model="submissionFormStore.fields[field.fieldname]"
+                                    :field="{
+                                        ...field,
+                                        reqd: shouldFieldBeRequired(
+                                            field,
+                                            submissionFormStore.fields,
+                                            allFields
+                                        ),
+                                    }"
+                                    :inEditMode="false"
+                                />
+                            </div>
+                        </template>
                     </div>
                 </template>
             </div>

--- a/frontend/src/composables/useGroupedRows.ts
+++ b/frontend/src/composables/useGroupedRows.ts
@@ -2,20 +2,28 @@ import { computed, type Ref } from "vue";
 import type { FormField } from "@/types/formfield";
 
 export function useGroupedRows(fields: Ref<FormField[]>) {
-  return computed<FormField[][]>(() => {
-    const rows = new Map<number, FormField[]>();
+  return computed<FormField[][][]>(() => {
+    const rows = new Map<number, Map<number, FormField[]>>();
     for (const f of fields.value) {
       const r = f.row_index ?? 0;
-      if (!rows.has(r)) rows.set(r, []);
-      rows.get(r)!.push(f);
+      const c = f.column_index ?? 0;
+      if (!rows.has(r)) rows.set(r, new Map());
+      const cols = rows.get(r)!;
+      if (!cols.has(c)) cols.set(c, []);
+      cols.get(c)!.push(f);
     }
     return [...rows.keys()]
       .sort((a, b) => a - b)
-      .map((r) =>
-        rows
-          .get(r)!
-          .slice()
-          .sort((a, b) => (a.column_index ?? 0) - (b.column_index ?? 0))
-      );
+      .map((r) => {
+        const cols = rows.get(r)!;
+        return [...cols.keys()]
+          .sort((a, b) => a - b)
+          .map((c) =>
+            cols
+              .get(c)!
+              .slice()
+              .sort((a, b) => (a.cell_index ?? 0) - (b.cell_index ?? 0))
+          );
+      });
   });
 }

--- a/frontend/src/composables/useGroupedRows.ts
+++ b/frontend/src/composables/useGroupedRows.ts
@@ -1,0 +1,21 @@
+import { computed, type Ref } from "vue";
+import type { FormField } from "@/types/formfield";
+
+export function useGroupedRows(fields: Ref<FormField[]>) {
+  return computed<FormField[][]>(() => {
+    const rows = new Map<number, FormField[]>();
+    for (const f of fields.value) {
+      const r = f.row_index ?? 0;
+      if (!rows.has(r)) rows.set(r, []);
+      rows.get(r)!.push(f);
+    }
+    return [...rows.keys()]
+      .sort((a, b) => a - b)
+      .map((r) =>
+        rows
+          .get(r)!
+          .slice()
+          .sort((a, b) => (a.column_index ?? 0) - (b.column_index ?? 0))
+      );
+  });
+}

--- a/frontend/src/stores/editForm.ts
+++ b/frontend/src/stores/editForm.ts
@@ -194,34 +194,111 @@ export const useEditForm = defineStore("editForm", () => {
     }
   }
 
+  function compact() {
+    const fs: FormField[] = formResource.value?.doc?.fields ?? [];
+    if (!fs.length) return;
+
+    // Remap row_index values to 0..N-1 (closes gaps left by deletions/moves)
+    const distinctRows = [...new Set(fs.map((f) => f.row_index ?? 0))].sort(
+      (a, b) => a - b
+    );
+    const rowRemap = new Map(distinctRows.map((r, i) => [r, i]));
+    for (const f of fs) {
+      f.row_index = rowRemap.get(f.row_index ?? 0) ?? 0;
+    }
+
+    // Renumber column_index within each row to 0..M-1
+    const rowMap = new Map<number, FormField[]>();
+    for (const f of fs) {
+      const r = f.row_index!;
+      if (!rowMap.has(r)) rowMap.set(r, []);
+      rowMap.get(r)!.push(f);
+    }
+    for (const row of rowMap.values()) {
+      row
+        .sort((a, b) => (a.column_index ?? 0) - (b.column_index ?? 0))
+        .forEach((f, i) => {
+          f.column_index = i;
+        });
+    }
+  }
+
   function addField(fieldtype: Fieldtype) {
     if (formResource.value?.doc) {
+      const fs: FormField[] = formResource.value.doc.fields;
+      const lastRow =
+        fs.length > 0 ? Math.max(...fs.map((f) => f.row_index ?? 0)) : -1;
+
       const newField: FormField = {
-        idx: formResource.value.doc.fields.length + 1,
+        idx: fs.length + 1,
         fieldtype,
         label: "",
         fieldname: "",
         options: "",
         default: "",
         description: "",
+        row_index: lastRow + 1,
+        column_index: 0,
       };
 
-      formResource.value.doc.fields.push(newField);
+      fs.push(newField);
     }
   }
 
   function addFieldFromDoctype(field: any) {
+    const fs: FormField[] = formResource.value.doc.fields;
+    const lastRow =
+      fs.length > 0 ? Math.max(...fs.map((f) => f.row_index ?? 0)) : -1;
+
     const _newField: FormField = {
-      idx: formResource.value.doc.fields.length + 1,
+      idx: fs.length + 1,
       fieldtype: field.fieldtype,
       label: field.label,
       fieldname: field.fieldname,
       options: field.options,
       default: field.default,
       description: field.description,
+      row_index: lastRow + 1,
+      column_index: 0,
     };
 
-    formResource.value.doc.fields.push(_newField);
+    fs.push(_newField);
+  }
+
+  function moveField(field: FormField, targetRow: number, targetCol: number) {
+    const fs: FormField[] = formResource.value?.doc?.fields ?? [];
+
+    // Shift existing columns in target row to open a slot
+    for (const f of fs) {
+      if (
+        f !== field &&
+        (f.row_index ?? 0) === targetRow &&
+        (f.column_index ?? 0) >= targetCol
+      ) {
+        f.column_index = (f.column_index ?? 0) + 1;
+      }
+    }
+
+    field.row_index = targetRow;
+    field.column_index = targetCol;
+
+    compact();
+  }
+
+  function insertNewRow(field: FormField, atRow: number) {
+    const fs: FormField[] = formResource.value?.doc?.fields ?? [];
+
+    // Push all rows at or below atRow down by 1
+    for (const f of fs) {
+      if (f !== field && (f.row_index ?? 0) >= atRow) {
+        f.row_index = (f.row_index ?? 0) + 1;
+      }
+    }
+
+    field.row_index = atRow;
+    field.column_index = 0;
+
+    compact();
   }
 
   function removeField(field: FormField) {
@@ -229,6 +306,7 @@ export const useEditForm = defineStore("editForm", () => {
       formResource.value.doc.fields = formResource.value.doc.fields.filter(
         (f: FormField) => f !== field
       );
+      compact();
     }
   }
 
@@ -277,5 +355,7 @@ export const useEditForm = defineStore("editForm", () => {
     selectField,
     updateField,
     removeField,
+    moveField,
+    insertNewRow,
   };
 });

--- a/frontend/src/stores/editForm.ts
+++ b/frontend/src/stores/editForm.ts
@@ -207,18 +207,36 @@ export const useEditForm = defineStore("editForm", () => {
       f.row_index = rowRemap.get(f.row_index ?? 0) ?? 0;
     }
 
-    // Renumber column_index within each row to 0..M-1
-    const rowMap = new Map<number, FormField[]>();
+    // Remap distinct column_index values within each row to 0..M-1
+    // (cells sharing a column_index stay grouped — multi-cell columns preserved)
+    const rowColsMap = new Map<number, Set<number>>();
     for (const f of fs) {
       const r = f.row_index!;
-      if (!rowMap.has(r)) rowMap.set(r, []);
-      rowMap.get(r)!.push(f);
+      if (!rowColsMap.has(r)) rowColsMap.set(r, new Set());
+      rowColsMap.get(r)!.add(f.column_index ?? 0);
     }
-    for (const row of rowMap.values()) {
-      row
-        .sort((a, b) => (a.column_index ?? 0) - (b.column_index ?? 0))
+    const colRemapByRow = new Map<number, Map<number, number>>();
+    for (const [r, cols] of rowColsMap) {
+      const sorted = [...cols].sort((a, b) => a - b);
+      colRemapByRow.set(r, new Map(sorted.map((c, i) => [c, i])));
+    }
+    for (const f of fs) {
+      f.column_index =
+        colRemapByRow.get(f.row_index!)!.get(f.column_index ?? 0) ?? 0;
+    }
+
+    // Renumber cell_index within each (row, column) to 0..K-1
+    const cellMap = new Map<string, FormField[]>();
+    for (const f of fs) {
+      const key = `${f.row_index}-${f.column_index}`;
+      if (!cellMap.has(key)) cellMap.set(key, []);
+      cellMap.get(key)!.push(f);
+    }
+    for (const cells of cellMap.values()) {
+      cells
+        .sort((a, b) => (a.cell_index ?? 0) - (b.cell_index ?? 0))
         .forEach((f, i) => {
-          f.column_index = i;
+          f.cell_index = i;
         });
     }
   }
@@ -241,6 +259,7 @@ export const useEditForm = defineStore("editForm", () => {
         description: "",
         row_index: lastRowIndex(fs) + 1,
         column_index: 0,
+        cell_index: 0,
       };
 
       fs.push(newField);
@@ -261,6 +280,7 @@ export const useEditForm = defineStore("editForm", () => {
       description: field.description,
       row_index: lastRowIndex(fs) + 1,
       column_index: 0,
+      cell_index: 0,
     };
 
     fs.push(_newField);
@@ -270,7 +290,8 @@ export const useEditForm = defineStore("editForm", () => {
     const fs: FormField[] = formResource.value?.doc?.fields ?? [];
     if (!fs.includes(field)) return;
 
-    // Shift existing columns in target row to open a slot
+    // Shift existing columns in target row to open a slot (whole columns shift,
+    // multi-cell columns stay grouped because all their cells share column_index)
     for (const f of fs) {
       if (
         f !== field &&
@@ -283,6 +304,35 @@ export const useEditForm = defineStore("editForm", () => {
 
     field.row_index = targetRow;
     field.column_index = targetCol;
+    field.cell_index = 0;
+
+    compact();
+  }
+
+  function insertCell(
+    field: FormField,
+    targetRow: number,
+    targetCol: number,
+    atCell: number
+  ) {
+    const fs: FormField[] = formResource.value?.doc?.fields ?? [];
+    if (!fs.includes(field)) return;
+
+    // Shift cells at or below atCell within (targetRow, targetCol) down by 1
+    for (const f of fs) {
+      if (
+        f !== field &&
+        (f.row_index ?? 0) === targetRow &&
+        (f.column_index ?? 0) === targetCol &&
+        (f.cell_index ?? 0) >= atCell
+      ) {
+        f.cell_index = (f.cell_index ?? 0) + 1;
+      }
+    }
+
+    field.row_index = targetRow;
+    field.column_index = targetCol;
+    field.cell_index = atCell;
 
     compact();
   }
@@ -300,6 +350,7 @@ export const useEditForm = defineStore("editForm", () => {
 
     field.row_index = atRow;
     field.column_index = 0;
+    field.cell_index = 0;
 
     compact();
   }
@@ -359,6 +410,7 @@ export const useEditForm = defineStore("editForm", () => {
     updateField,
     removeField,
     moveField,
+    insertCell,
     insertNewRow,
   };
 });

--- a/frontend/src/stores/editForm.ts
+++ b/frontend/src/stores/editForm.ts
@@ -223,11 +223,13 @@ export const useEditForm = defineStore("editForm", () => {
     }
   }
 
+  function lastRowIndex(fs: FormField[]): number {
+    return fs.reduce((m, f) => Math.max(m, f.row_index ?? 0), -1);
+  }
+
   function addField(fieldtype: Fieldtype) {
     if (formResource.value?.doc) {
       const fs: FormField[] = formResource.value.doc.fields;
-      const lastRow =
-        fs.length > 0 ? Math.max(...fs.map((f) => f.row_index ?? 0)) : -1;
 
       const newField: FormField = {
         idx: fs.length + 1,
@@ -237,7 +239,7 @@ export const useEditForm = defineStore("editForm", () => {
         options: "",
         default: "",
         description: "",
-        row_index: lastRow + 1,
+        row_index: lastRowIndex(fs) + 1,
         column_index: 0,
       };
 
@@ -246,9 +248,8 @@ export const useEditForm = defineStore("editForm", () => {
   }
 
   function addFieldFromDoctype(field: any) {
+    if (!formResource.value?.doc) return;
     const fs: FormField[] = formResource.value.doc.fields;
-    const lastRow =
-      fs.length > 0 ? Math.max(...fs.map((f) => f.row_index ?? 0)) : -1;
 
     const _newField: FormField = {
       idx: fs.length + 1,
@@ -258,7 +259,7 @@ export const useEditForm = defineStore("editForm", () => {
       options: field.options,
       default: field.default,
       description: field.description,
-      row_index: lastRow + 1,
+      row_index: lastRowIndex(fs) + 1,
       column_index: 0,
     };
 
@@ -267,6 +268,7 @@ export const useEditForm = defineStore("editForm", () => {
 
   function moveField(field: FormField, targetRow: number, targetCol: number) {
     const fs: FormField[] = formResource.value?.doc?.fields ?? [];
+    if (!fs.includes(field)) return;
 
     // Shift existing columns in target row to open a slot
     for (const f of fs) {
@@ -287,6 +289,7 @@ export const useEditForm = defineStore("editForm", () => {
 
   function insertNewRow(field: FormField, atRow: number) {
     const fs: FormField[] = formResource.value?.doc?.fields ?? [];
+    if (!fs.includes(field)) return;
 
     // Push all rows at or below atRow down by 1
     for (const f of fs) {

--- a/frontend/src/types/FormsPro/form_field.types.ts
+++ b/frontend/src/types/FormsPro/form_field.types.ts
@@ -34,6 +34,10 @@ export interface FormField {
   parentfield?: string;
   parenttype?: string;
   idx?: number;
+  /**	Row Index : Int	*/
+  row_index?: number;
+  /**	Column Index : Int	*/
+  column_index?: number;
   /**	Mandatory : Check	*/
   reqd?: 0 | 1;
   /**	Hidden : Check	*/

--- a/frontend/src/types/FormsPro/form_field.types.ts
+++ b/frontend/src/types/FormsPro/form_field.types.ts
@@ -38,6 +38,8 @@ export interface FormField {
   row_index?: number;
   /**	Column Index : Int	*/
   column_index?: number;
+  /**	Cell Index : Int	*/
+  cell_index?: number;
   /**	Mandatory : Check	*/
   reqd?: 0 | 1;
   /**	Hidden : Check	*/

--- a/frontend/src/types/formfield.ts
+++ b/frontend/src/types/formfield.ts
@@ -14,4 +14,5 @@ export type FormField = {
   conditional_logic?: string;
   row_index?: number;
   column_index?: number;
+  cell_index?: number;
 };

--- a/frontend/src/types/formfield.ts
+++ b/frontend/src/types/formfield.ts
@@ -12,4 +12,6 @@ export type FormField = {
   default?: string;
   idx?: number;
   conditional_logic?: string;
+  row_index?: number;
+  column_index?: number;
 };


### PR DESCRIPTION
## Summary

Adds spatial drag-and-drop multi-column layout to the form builder, with vertical cell stacking inside columns.

- New `row_index` + `column_index` + `cell_index` integer columns on `FormField`. Sort key: `(row_index, column_index, cell_index)`. Layout is purely presentational, never serialized to the linked DocType's `CustomField`.
- Builder canvas: row → column → cell render. Drag a field card horizontally onto a `ColumnDropZone` to add a new column. Drop onto another column's cell list to stack as a new cell. `RowDropZone` between rows still creates a fresh full-width row. Eject button on multi-column fields restores them to their own row.
- Submission renderer: row-grouped with `flex flex-col md:flex-row` (mobile stack, desktop side-by-side). `v-if` per row/column/cell so hidden fields fully unmount.
- Store helpers (`compact`, `moveField`, `insertCell`, `insertNewRow`) keep the three axes contiguous after every mutation.
- Backfill patch + Python tests asserting layout fields are excluded from `to_frappe_field` for every fieldtype.

https://github.com/user-attachments/assets/4e901aa4-f386-4eb2-9447-f0391bb30888


## Tests

Playwright e2e covers all builder + renderer flows (`frontend/e2e/specs/form-layout.spec.ts`):

- [x] Cell stacks into existing column on drag
- [x] Column drop zone creates new column
- [x] Row drop zone creates new row
- [x] Eject moves cell to new row
- [x] Cross-row drag collapses source column
- [x] Within-column reorder renumbers `cell_index`
- [x] Mobile viewport (375x800) stacks columns vertically
- [x] Hidden field unmounts column, no empty gap
- [x] `bench run-tests --app forms_pro` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-column and multi-row form layout support with enhanced drag-and-drop capabilities
  * Introduced column and row drop zones for improved form field organization
  * Added "eject" action to move form fields to their own rows
  * Form layouts now properly render across multiple columns with responsive mobile stacking

* **Tests**
  * Expanded test coverage for form field layout validation and positioning

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BuildWithHussain/forms_pro/pull/119)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->