### PR TITLE
fix(e2e): detect cross-row drag via data-row-index

### DIFF
--- a/frontend/e2e/helpers/form-builder.ts
+++ b/frontend/e2e/helpers/form-builder.ts
@@ -123,15 +123,23 @@ export class FormBuilderPage {
       y: box.y + yOffset,
     };
 
-    // If the drag crosses rows (different y bands), route through a
-    // waypoint that lives in the row drop zone between rows. This avoids
-    // accidentally swapping into another sortable instance (e.g. the
-    // neighbouring column in the source row) while passing through.
-    // Anchor the waypoint to the actual RowDropZone bounding box so the
-    // helper stays robust if the zone's visual size changes.
+    // If the drag crosses rows, route through a waypoint that lives in the
+    // row drop zone between rows. This avoids accidentally swapping into
+    // another sortable instance (e.g. the neighbouring column in the source
+    // row) while passing through. Detect cross-row by comparing the cards'
+    // data-row-index attributes, which is robust to drop-zone size changes
+    // (a y-distance heuristic broke once RowDropZone shrank from h-6 to
+    // h-3, because adjacent rows became close enough that the vertical gap
+    // was smaller than a card's height).
     const waypoints: { x: number; y: number }[] = [];
     const sourceMidY = sourceBox.y + sourceBox.height / 2;
-    const isCrossRow = Math.abs(targetCenter.y - sourceMidY) > sourceBox.height;
+    const sourceRow = Number(
+      (await source.getAttribute("data-row-index")) ?? 0
+    );
+    const targetRow = Number(
+      (await target.getAttribute("data-row-index")) ?? 0
+    );
+    const isCrossRow = sourceRow !== targetRow;
     if (isCrossRow) {
       // Pick the row-drop-zone whose centre lies in the vertical band
       // between source and target — robust to duplicate data-at-row values


### PR DESCRIPTION
## Problem

UI Tests on `develop` (run [25745138544](https://github.com/BuildWithHussain/forms_pro/actions/runs/25745138544)) fails on one Playwright spec:

`frontend/e2e/specs/form-layout.spec.ts:144` — *cross-row drag collapses source column*

```
> 172 |     await expect.poll(() => builder.cellCount(1, 0)).toBe(2);
       Expected: 2  Received: 1
```

Failure screenshot shows `B` ended up in its own row between `A` and `C/D` (3 rows total), not stacked above `C`.

## Root cause

`dragFieldOntoCell` decides whether to inject a routing waypoint based on a y-distance heuristic:

```ts
const isCrossRow = Math.abs(targetCenter.y - sourceMidY) > sourceBox.height;
```

After 3c72b20 shrank `RowDropZone` from `h-6` (24px) to `h-3` (12px), adjacent rows sit close enough that the vertical gap between B center and C's upper quarter (~60px) is **smaller** than a card's height (~80px). So `isCrossRow` evaluates `false` for a clearly cross-row drag.

With no waypoint, the helper takes the direct path from source to target. The path crosses the `RowDropZone` between rows, and the drop commits there. `onRowZoneDrop` calls `insertNewRow`, putting B into its own row.

Playwright trace from the failing run confirms only two mouse moves (midpoint + target) post-nudge, meaning the cross-row branch was skipped.

## Fix

Detect cross-row by comparing `data-row-index` attributes on the source and target `FieldCard` locators. Robust to any future drop-zone size changes.

## Test plan

CI will run the full Playwright suite. The previously failing spec `form-layout.spec.ts:144` should now pass; other layout drag tests are unaffected (they either operate within a single row or use `dragFieldToRowZone` / `dragFieldToColumnZone` which do not rely on this heuristic).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced form field drag detection in automated tests to be more resilient to UI geometry changes, improving test stability and reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BuildWithHussain/forms_pro/pull/132)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->