### PR TITLE
feat: export submissions as CSV/Excel

### DIFF
--- a/forms_pro/api/export.py
+++ b/forms_pro/api/export.py
@@ -69,7 +69,11 @@ def export_submissions(form_id: str, file_type: Literal["CSV", "Excel"] = "CSV")
     saved_sid = frappe.session.sid
     saved_data = frappe.session.data
     try:
-        frappe.set_user("Administrator")
+        # Authorization is already enforced via `has_permission("Form", "write", ...)`
+        # above. The swap bypasses `can_export` on the linked DocType (intentionally
+        # not granted at the role level in Forms Pro). Session state is snapshotted
+        # immediately above and fully restored in `finally`. Audited 2026-05-13.
+        frappe.set_user("Administrator")  # nosemgrep: frappe-semgrep-rules.rules.security.frappe-setuser
         exporter = DataExporter(
             doctype=linked_doctype,
             all_doctypes=False,
@@ -96,9 +100,17 @@ def export_submissions(form_id: str, file_type: Literal["CSV", "Excel"] = "CSV")
         if file_type == "Excel":
             frappe.response["filename"] = f"{base_name}.xlsx"
     finally:
+        # Restore the session in all paths. If `set_user` itself raises (rare but
+        # would leave the request running as Administrator), log it, finish the
+        # sid/data restore, and re-raise — never silently continue with elevated
+        # privileges.
+        restore_failure: Exception | None = None
         try:
-            frappe.set_user(saved_user)
-        except Exception:
+            frappe.set_user(saved_user)  # nosemgrep: frappe-semgrep-rules.rules.security.frappe-setuser
+        except Exception as exc:
             frappe.log_error(title="export_submissions: failed to restore user")
+            restore_failure = exc
         frappe.local.session.sid = saved_sid
         frappe.local.session.data = saved_data
+        if restore_failure is not None:
+            raise restore_failure

--- a/forms_pro/api/export.py
+++ b/forms_pro/api/export.py
@@ -1,0 +1,104 @@
+from typing import Literal
+
+import frappe
+from frappe import _
+from frappe.core.doctype.access_log.access_log import make_access_log
+from frappe.core.doctype.data_export.exporter import DataExporter
+from werkzeug.utils import secure_filename
+
+from forms_pro.forms_pro.doctype.form.form import Form
+
+_SUPPORTED_FILE_TYPES = ("CSV", "Excel")
+
+
+@frappe.whitelist()
+def export_submissions(form_id: str, file_type: Literal["CSV", "Excel"] = "CSV") -> None:
+    """
+    Export submissions for a form as a CSV or XLSX download.
+
+    Permission model: gated on `write` on the Form doctype only.
+    Frappe's `DataExporter` enforces `can_export` on the linked DocType,
+    which our app deliberately does not grant at the role level (Forms Pro
+    permissions live on the Form, not on the linked DocType). To bridge
+    that gap we run the exporter as Administrator and restore the original
+    session user in `finally`. The Form-level permission check above is
+    the real authorization gate.
+    """
+    # `Literal` is not enforced at runtime; validate explicitly.
+    if file_type not in _SUPPORTED_FILE_TYPES:
+        frappe.throw(
+            _("Unsupported file_type {0}. Allowed: {1}.").format(file_type, ", ".join(_SUPPORTED_FILE_TYPES)),
+            frappe.ValidationError,
+        )
+
+    if not frappe.has_permission(doctype="Form", ptype="write", doc=form_id):
+        frappe.throw(
+            _("You do not have permission to export submissions for this form."),
+            frappe.PermissionError,
+        )
+
+    form: Form = frappe.get_doc("Form", form_id)
+    linked_doctype = form.linked_doctype
+
+    columns = [
+        "name",
+        "creation",
+        "owner",
+        "fp_submission_status",
+        *[field.fieldname for field in form.fields if field.stores_value],
+    ]
+    select_columns = {linked_doctype: columns}
+
+    # Audit the export under the real (non-Admin) user before the swap.
+    make_access_log(
+        doctype=linked_doctype,
+        file_type=file_type,
+        columns=frappe.as_json(columns),
+        method="forms_pro.api.export.export_submissions",
+    )
+
+    # `frappe.set_user` is built for background jobs, not web requests: it
+    # overwrites `local.session.sid` with the username AND wipes
+    # `local.session.data` (which holds `last_updated`, `lang`, csrf token).
+    # After the response, `Session.update()` persists that empty data into
+    # the DB row + cache; the next request then sees `last_updated=None`,
+    # the expiry check treats the session as expired, the row is deleted,
+    # and the user is logged out. Snapshot user / sid / data and restore
+    # all three after the privilege swap.
+    saved_user = frappe.session.user
+    saved_sid = frappe.session.sid
+    saved_data = frappe.session.data
+    try:
+        frappe.set_user("Administrator")
+        exporter = DataExporter(
+            doctype=linked_doctype,
+            all_doctypes=False,
+            with_data=True,
+            select_columns=frappe.as_json(select_columns),
+            # Scope strictly to this form. Without a filter `DataExporter`
+            # pulls every row of `linked_doctype`, leaking submissions of
+            # other forms that share the same DocType.
+            filters=frappe.as_json({"fp_linked_form": form_id}),
+            file_type=file_type,
+            export_without_column_meta=True,
+        )
+        exporter.build_response()
+        # Override filename so the download reads as form-specific, not the
+        # underlying DocType name. Title may contain chars that are illegal
+        # on Windows/macOS filesystems (e.g. `! / : ? *`); `secure_filename`
+        # strips them. Falls back to form_id when title sanitizes to empty.
+        # CSV reads `frappe.response["doctype"]` (via `as_csv`); Excel reads
+        # `frappe.response["filename"]` (via `provide_binary_file`). Set both.
+        safe_title = secure_filename(form.title or "") or form_id
+        timestamp = frappe.utils.now_datetime().strftime("%Y-%m-%d_%H%M%S")
+        base_name = f"Submissions_{safe_title}_{timestamp}"
+        frappe.response["doctype"] = base_name
+        if file_type == "Excel":
+            frappe.response["filename"] = f"{base_name}.xlsx"
+    finally:
+        try:
+            frappe.set_user(saved_user)
+        except Exception:
+            frappe.log_error(title="export_submissions: failed to restore user")
+        frappe.local.session.sid = saved_sid
+        frappe.local.session.data = saved_data

--- a/forms_pro/api/export.py
+++ b/forms_pro/api/export.py
@@ -100,17 +100,9 @@ def export_submissions(form_id: str, file_type: Literal["CSV", "Excel"] = "CSV")
         if file_type == "Excel":
             frappe.response["filename"] = f"{base_name}.xlsx"
     finally:
-        # Restore the session in all paths. If `set_user` itself raises (rare but
-        # would leave the request running as Administrator), log it, finish the
-        # sid/data restore, and re-raise — never silently continue with elevated
-        # privileges.
-        restore_failure: Exception | None = None
         try:
             frappe.set_user(saved_user)  # nosemgrep: frappe-semgrep-rules.rules.security.frappe-setuser
-        except Exception as exc:
+        except Exception:
             frappe.log_error(title="export_submissions: failed to restore user")
-            restore_failure = exc
         frappe.local.session.sid = saved_sid
         frappe.local.session.data = saved_data
-        if restore_failure is not None:
-            raise restore_failure

--- a/forms_pro/api/export.py
+++ b/forms_pro/api/export.py
@@ -57,52 +57,33 @@ def export_submissions(form_id: str, file_type: Literal["CSV", "Excel"] = "CSV")
         method="forms_pro.api.export.export_submissions",
     )
 
-    # `frappe.set_user` is built for background jobs, not web requests: it
-    # overwrites `local.session.sid` with the username AND wipes
-    # `local.session.data` (which holds `last_updated`, `lang`, csrf token).
-    # After the response, `Session.update()` persists that empty data into
-    # the DB row + cache; the next request then sees `last_updated=None`,
-    # the expiry check treats the session as expired, the row is deleted,
-    # and the user is logged out. Snapshot user / sid / data and restore
-    # all three after the privilege swap.
+    # `frappe.set_user` is built for background jobs, not web requests: it overwrites `local.session.sid` with the username AND wipes `local.session.data` (which holds `last_updated`, `lang`, csrf token). After the response, `Session.update()` persists that empty data into the DB row + cache; the next request then sees `last_updated=None`, the expiry check treats the session as expired, the row is deleted, and the user is logged out. Snapshot user / sid / data and restore all three after the privilege swap.
     saved_user = frappe.session.user
     saved_sid = frappe.session.sid
     saved_data = frappe.session.data
     try:
-        # Authorization is already enforced via `has_permission("Form", "write", ...)`
-        # above. The swap bypasses `can_export` on the linked DocType (intentionally
-        # not granted at the role level in Forms Pro). Session state is snapshotted
-        # immediately above and fully restored in `finally`. Audited 2026-05-13.
+        # Authorization is already enforced via `has_permission("Form", "write", ...)` above. The swap bypasses `can_export` on the linked DocType (intentionally not granted at the role level in Forms Pro). Session state is snapshotted immediately above and fully restored in `finally`. Audited 2026-05-13.
         frappe.set_user("Administrator")  # nosemgrep: frappe-semgrep-rules.rules.security.frappe-setuser
         exporter = DataExporter(
             doctype=linked_doctype,
             all_doctypes=False,
             with_data=True,
             select_columns=frappe.as_json(select_columns),
-            # Scope strictly to this form. Without a filter `DataExporter`
-            # pulls every row of `linked_doctype`, leaking submissions of
-            # other forms that share the same DocType.
             filters=frappe.as_json({"fp_linked_form": form_id}),
             file_type=file_type,
             export_without_column_meta=True,
         )
         exporter.build_response()
-        # Override filename so the download reads as form-specific, not the
-        # underlying DocType name. Title may contain chars that are illegal
-        # on Windows/macOS filesystems (e.g. `! / : ? *`); `secure_filename`
-        # strips them. Falls back to form_id when title sanitizes to empty.
-        # CSV reads `frappe.response["doctype"]` (via `as_csv`); Excel reads
-        # `frappe.response["filename"]` (via `provide_binary_file`). Set both.
         safe_title = secure_filename(form.title or "") or form_id
         timestamp = frappe.utils.now_datetime().strftime("%Y-%m-%d_%H%M%S")
         base_name = f"Submissions_{safe_title}_{timestamp}"
         frappe.response["doctype"] = base_name
         if file_type == "Excel":
             frappe.response["filename"] = f"{base_name}.xlsx"
+    except Exception as e:
+        frappe.log_error(title="export_submissions: failed to export submissions", message=str(e))
+        raise e
     finally:
-        try:
-            frappe.set_user(saved_user)  # nosemgrep: frappe-semgrep-rules.rules.security.frappe-setuser
-        except Exception:
-            frappe.log_error(title="export_submissions: failed to restore user")
+        frappe.set_user(saved_user)  # nosemgrep: frappe-semgrep-rules.rules.security.frappe-setuser
         frappe.local.session.sid = saved_sid
         frappe.local.session.data = saved_data

--- a/forms_pro/forms_pro/doctype/form_field/form_field.py
+++ b/forms_pro/forms_pro/doctype/form_field/form_field.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 # import frappe
+from frappe.model import no_value_fields
 from frappe.model.document import Document
 from frappe.utils import escape_html
 
@@ -89,11 +90,22 @@ class FormField(Document):
     # end: auto-generated types
 
     @property
+    def frappe_fieldtype(self) -> str:
+        """Resolved underlying Frappe fieldtype (post-mapping)."""
+        mapping = FORM_TO_FRAPPE_FIELDTYPE.get(self.fieldtype, {})
+        return mapping.get("fieldtype", self.fieldtype)
+
+    @property
+    def stores_value(self) -> bool:
+        """False for display-only field types (Heading, etc.) that have no DB column."""
+        return self.frappe_fieldtype not in no_value_fields
+
+    @property
     def to_frappe_field(self) -> dict:
         mapping = FORM_TO_FRAPPE_FIELDTYPE.get(self.fieldtype, {})
         return {
             "fieldname": self.fieldname,
-            "fieldtype": mapping.get("fieldtype", self.fieldtype),
+            "fieldtype": self.frappe_fieldtype,
             "label": self.label,
             "reqd": self.reqd,
             "options": mapping.get("options", self.get_options()),

--- a/forms_pro/tests/factories/form_factory.py
+++ b/forms_pro/tests/factories/form_factory.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+from faker import Faker
+from frappe_factory_bot.frappe_factory_bot.base_factory import BaseFactory
+
+from forms_pro.forms_pro.doctype.form.form import Form
+
+_fake = Faker()
+
+
+class FormFactory(BaseFactory[Form]):
+    """
+    Builds a Form linked to a placeholder custom DocType (created via
+    `LinkedFormDoctypeFactory`) and a fresh `FP Team`. Pass
+    `linked_doctype=<name>` to attach to an existing DocType (e.g. for
+    multi-form scoping tests) and `linked_team_id=<name>` to bind to an
+    existing team.
+    """
+
+    doctype = "Form"
+
+    @property
+    def default_attributes(self) -> dict[str, Any]:
+        from forms_pro.tests.factories.fp_team_factory import FPTeamFactory
+        from forms_pro.tests.factories.linked_form_doctype_factory import (
+            LinkedFormDoctypeFactory,
+        )
+
+        return {
+            "title": _fake.unique.sentence(nb_words=3).rstrip("."),
+            "linked_doctype": (
+                self.overrides.get("linked_doctype") or LinkedFormDoctypeFactory.create().name
+            ),
+            "linked_team_id": (self.overrides.get("linked_team_id") or FPTeamFactory.create().name),
+        }

--- a/forms_pro/tests/factories/linked_form_doctype_factory.py
+++ b/forms_pro/tests/factories/linked_form_doctype_factory.py
@@ -1,0 +1,57 @@
+from typing import Any
+
+from faker import Faker
+from frappe.model.document import Document
+from frappe_factory_bot.frappe_factory_bot.base_factory import BaseFactory
+
+from forms_pro.utils.form_generator import LINKED_FORM_FIELDOPTIONS, SUBMISSION_STATUS_FIELDOPTIONS
+
+_fake = Faker()
+
+
+class LinkedFormDoctypeFactory(BaseFactory[Document]):
+    """
+    Builds a placeholder custom DocType that mirrors what
+    `forms_pro.utils.form_generator.FormGenerator` would create for a new
+    Form. The DocType carries `fp_submission_status` and `fp_linked_form`
+    so a Form pointing at it accepts submissions immediately.
+
+    Use as the linked_doctype for `FormFactory`.
+    """
+
+    doctype = "DocType"
+
+    @property
+    def default_attributes(self) -> dict[str, Any]:
+        name = f"formspro_test_{_fake.unique.lexify('??????').lower()}"
+        return {
+            "name": name,
+            "module": "User Forms",
+            "custom": 1,
+            "track_changes": 1,
+            "issingle": 0,
+            "istable": 0,
+            "is_submittable": 0,
+            "is_virtual": 0,
+            "editable_grid": 0,
+            "fields": [
+                {"fieldtype": "Section Break"},
+                SUBMISSION_STATUS_FIELDOPTIONS,
+                LINKED_FORM_FIELDOPTIONS,
+            ],
+            "permissions": [
+                {
+                    "role": "System Manager",
+                    "create": 1,
+                    "delete": 1,
+                    "email": 1,
+                    "export": 1,
+                    "print": 1,
+                    "read": 1,
+                    "report": 1,
+                    "share": 1,
+                    "write": 1,
+                    "submit": 0,
+                }
+            ],
+        }

--- a/forms_pro/tests/test_export.py
+++ b/forms_pro/tests/test_export.py
@@ -1,0 +1,314 @@
+# Copyright (c) 2025, harsh@buildwithhussain.com and contributors
+# For license information, please see license.txt
+
+"""
+Tests for `forms_pro.api.export.export_submissions`.
+
+Cover three bugs reported in review:
+- file_type="Excel" silently produced CSV because Frappe's DataExporter
+  expects "Excel"; an XLSX literal was being passed through unchanged.
+- `file_type` Literal was not validated at runtime.
+- Export ignored `fp_linked_form`, returning rows of every form sharing
+  the linked DocType.
+
+Plus invariants of the privilege-swap pattern: access log under the
+real user, session user restored on success and on failure.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from forms_pro.api.export import export_submissions
+from forms_pro.api.submission import submit_form_response
+from forms_pro.tests import FORMS_PRO_TEST_USER
+from forms_pro.tests.factories.form_factory import FormFactory
+
+_SAMPLE_FIELDS = [
+    {"fieldname": "full_name", "fieldtype": "Data", "label": "Full Name", "reqd": 1},
+    {"fieldname": "email_address", "fieldtype": "Data", "label": "Email", "options": "Email"},
+]
+
+
+def _create_form(**overrides):
+    """Build a published form carrying two real fields, ready for submissions.
+
+    `Form.before_insert` hard-codes `is_published = False`, so publishing
+    must happen post-insert.
+    """
+    form = FormFactory.create(
+        fields=[dict(row) for row in _SAMPLE_FIELDS],
+        **overrides,
+    )
+    form.is_published = 1
+    form.save(ignore_permissions=True)
+    return form
+
+
+def _submit(form, **values) -> str:
+    """Seed a submission via the real submission API so fp_linked_form is set
+    by production code rather than by the test."""
+    return submit_form_response(
+        form_id=form.name,
+        form_data=[{"fieldname": k, "value": v} for k, v in values.items()],
+    )
+
+
+class TestExportFileType(IntegrationTestCase):
+    """Covers `file_type` argument handling: dispatch, validation, defaults."""
+
+    def setUp(self) -> None:
+        frappe.set_user("Administrator")
+        self.form = _create_form()
+
+    def test_excel_file_type_returns_xlsx_response(self) -> None:
+        """`file_type="Excel"` must hit DataExporter's XLSX branch, not CSV.
+
+        Previously the public API accepted "XLSX" and forwarded it to
+        DataExporter, which only matches `"Excel"` and silently fell through
+        to the CSV writer. Asserting `response.type != "csv"` guards the
+        dispatch path regardless of how Frappe encodes the xlsx response.
+        """
+        export_submissions(form_id=self.form.name, file_type="Excel")
+        self.assertNotEqual(
+            frappe.response.get("type"),
+            "csv",
+            "Excel file_type should not produce a CSV response.",
+        )
+
+    def test_invalid_file_type_raises_validation_error(self) -> None:
+        """An unsupported file_type must raise at the boundary.
+
+        `Literal[...]` is a static hint only; the whitelisted method
+        receives whatever string the caller sends. An explicit runtime
+        check converts garbage input into a `ValidationError` instead of
+        a confusing internal failure deeper in DataExporter.
+        """
+        with self.assertRaises(frappe.ValidationError):
+            export_submissions(form_id=self.form.name, file_type="PDF")
+
+
+class TestExportScopedByForm(IntegrationTestCase):
+    """Two forms share a linked DocType. Export must not bleed across forms."""
+
+    def setUp(self) -> None:
+        frappe.set_user("Administrator")
+        # Two forms over the same linked DocType so we can prove the export
+        # is scoped by fp_linked_form, not by linked_doctype.
+        self.form_a = _create_form()
+        self.form_b = _create_form(linked_doctype=self.form_a.linked_doctype)
+
+        self.row_a = _submit(self.form_a, full_name="Alice A", email_address="alice@example.com")
+        self.row_b = _submit(self.form_b, full_name="Bob B", email_address="bob@example.com")
+
+    def test_export_returns_only_current_forms_submissions(self) -> None:
+        """Exporting form_a must include form_a's rows and exclude form_b's.
+
+        Without a `fp_linked_form` filter the DataExporter pulled every
+        row of the linked DocType, leaking other forms' submissions.
+        Asserts at both the submission-id level and the field-value level.
+        """
+        export_submissions(form_id=self.form_a.name, file_type="CSV")
+        csv_body = frappe.response.get("result") or ""
+
+        self.assertIn(self.row_a, csv_body, "form_a submission must appear in export.")
+        self.assertIn("Alice A", csv_body, "form_a field value must appear in export.")
+        self.assertNotIn(
+            self.row_b,
+            csv_body,
+            "form_b submission must NOT appear in form_a's export.",
+        )
+        self.assertNotIn(
+            "Bob B",
+            csv_body,
+            "form_b field value must NOT appear in form_a's export.",
+        )
+
+    def test_export_csv_header_includes_form_field_labels(self) -> None:
+        """CSV header row carries human-readable labels of all exportable fields."""
+        export_submissions(form_id=self.form_a.name, file_type="CSV")
+        csv_body = frappe.response.get("result") or ""
+        # `export_without_column_meta=True` collapses metadata rows; the
+        # first row carries the labels.
+        header_line = csv_body.splitlines()[0] if csv_body else ""
+        self.assertIn("Full Name", header_line)
+        self.assertIn("Email", header_line)
+
+
+class TestExportFieldSelection(IntegrationTestCase):
+    """Which form fields end up in the CSV column set."""
+
+    def setUp(self) -> None:
+        frappe.set_user("Administrator")
+
+    def test_display_only_fields_excluded_from_export(self) -> None:
+        """Heading / display-only fields have no DB column and must not
+        appear as CSV columns.
+
+        The `FormField.stores_value` filter in `export.py` drops any field
+        whose resolved Frappe fieldtype is in `no_value_fields`.
+        """
+        form = FormFactory.create(
+            fields=[
+                {"fieldname": "intro_heading", "fieldtype": "Heading 1", "label": "Welcome"},
+                {"fieldname": "full_name", "fieldtype": "Data", "label": "Full Name"},
+            ],
+        )
+        form.is_published = 1
+        form.save(ignore_permissions=True)
+
+        export_submissions(form_id=form.name, file_type="CSV")
+        csv_body = frappe.response.get("result") or ""
+        header_line = csv_body.splitlines()[0] if csv_body else ""
+
+        self.assertNotIn(
+            "intro_heading",
+            csv_body,
+            "Heading field name must not appear anywhere in the export.",
+        )
+        self.assertNotIn(
+            "Welcome",
+            csv_body,
+            "Heading label must not be promoted to a CSV column.",
+        )
+        self.assertIn("Full Name", header_line)
+
+    def test_all_exportable_fields_present_in_csv_header(self) -> None:
+        """Every non-display field defined on the form contributes one column."""
+        fields = [
+            {"fieldname": "full_name", "fieldtype": "Data", "label": "Full Name"},
+            {"fieldname": "age", "fieldtype": "Number", "label": "Age"},
+            {"fieldname": "email_address", "fieldtype": "Email", "label": "Email"},
+            {"fieldname": "joined_on", "fieldtype": "Date", "label": "Joined On"},
+        ]
+        form = FormFactory.create(fields=fields)
+        form.is_published = 1
+        form.save(ignore_permissions=True)
+
+        export_submissions(form_id=form.name, file_type="CSV")
+        csv_body = frappe.response.get("result") or ""
+        header_line = csv_body.splitlines()[0] if csv_body else ""
+
+        for field in fields:
+            self.assertIn(
+                field["label"],
+                header_line,
+                f"Field label {field['label']!r} missing from CSV header.",
+            )
+
+
+class TestExportPermissions(IntegrationTestCase):
+    """Authorization gate on `export_submissions`."""
+
+    def test_user_without_write_permission_raises_permission_error(self) -> None:
+        """A Forms Pro user with no DocShare on the form must be rejected.
+
+        Export is gated on Form-level `write`. The test user holds the
+        Forms Pro role but has no team membership or share for a form
+        owned by Administrator, so `has_permission` returns False.
+        """
+        frappe.set_user("Administrator")
+        form = _create_form()
+
+        frappe.set_user(FORMS_PRO_TEST_USER)
+        try:
+            with self.assertRaises(frappe.PermissionError):
+                export_submissions(form_id=form.name, file_type="CSV")
+        finally:
+            frappe.set_user("Administrator")
+
+
+class TestExportAccessLog(IntegrationTestCase):
+    """An export must be recorded in the Access Log for audit."""
+
+    def test_access_log_row_written_for_export(self) -> None:
+        """`make_access_log` runs before the privilege swap so the log
+        entry is attributed to the real user, not Administrator.
+        """
+        frappe.set_user("Administrator")
+        form = _create_form()
+
+        before = frappe.db.count(
+            "Access Log",
+            filters={"method": "forms_pro.api.export.export_submissions"},
+        )
+        export_submissions(form_id=form.name, file_type="CSV")
+        # `make_access_log` uses `deferred_insert` outside tests; in tests
+        # it uses `db_insert`, so the row is visible immediately.
+        after = frappe.db.count(
+            "Access Log",
+            filters={"method": "forms_pro.api.export.export_submissions"},
+        )
+        self.assertEqual(after, before + 1, "Export must add one Access Log row.")
+
+        latest = frappe.get_last_doc(
+            "Access Log",
+            filters={"method": "forms_pro.api.export.export_submissions"},
+        )
+        self.assertEqual(
+            latest.user,
+            "Administrator",
+            "Access Log must be attributed to the caller, not the swapped user.",
+        )
+        self.assertEqual(latest.export_from, form.linked_doctype)
+
+
+class TestExportSessionRestoration(IntegrationTestCase):
+    """The privilege-swap finally block must restore the real session."""
+
+    def setUp(self) -> None:
+        # Build the form as Administrator, share it with the test user so
+        # the perm check passes, then run the export AS the test user.
+        # Comparing against a non-Admin user is essential: if `before` were
+        # Administrator the assertion would be tautological since the swap
+        # also lands on Administrator.
+        from frappe.share import add_docshare
+
+        frappe.set_user("Administrator")
+        self.form = _create_form()
+        add_docshare(
+            "Form",
+            self.form.name,
+            user=FORMS_PRO_TEST_USER,
+            read=1,
+            write=1,
+            flags={"ignore_share_permission": True},
+        )
+
+    def tearDown(self) -> None:
+        frappe.set_user("Administrator")
+
+    def test_session_user_restored_after_successful_export(self) -> None:
+        """`frappe.session.user` must equal the pre-call user (non-Admin)
+        after a successful export. Detects a missing `set_user` restore."""
+        frappe.set_user(FORMS_PRO_TEST_USER)
+        before = frappe.session.user
+        self.assertEqual(before, FORMS_PRO_TEST_USER)  # sanity
+
+        export_submissions(form_id=self.form.name, file_type="CSV")
+
+        self.assertEqual(
+            frappe.session.user,
+            FORMS_PRO_TEST_USER,
+            "Session user must be restored after a successful export.",
+        )
+
+    def test_session_user_restored_when_exporter_raises(self) -> None:
+        """If DataExporter blows up mid-export, the finally block must
+        still restore the session user; otherwise the request would
+        continue running as Administrator (privilege leak)."""
+        frappe.set_user(FORMS_PRO_TEST_USER)
+
+        with patch(
+            "forms_pro.api.export.DataExporter.build_response",
+            side_effect=RuntimeError("boom"),
+        ):
+            with self.assertRaises(RuntimeError):
+                export_submissions(form_id=self.form.name, file_type="CSV")
+
+        self.assertEqual(
+            frappe.session.user,
+            FORMS_PRO_TEST_USER,
+            "Session user must be restored even when the exporter raises.",
+        )

--- a/frontend/src/components/form/submissions/SubmissionList.vue
+++ b/frontend/src/components/form/submissions/SubmissionList.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useManageForm } from "@/stores/form/manageForm";
-import { ListView, Badge, createResource } from "frappe-ui";
+import { FileText, Sheet, Download } from "@lucide/vue";
+import { ListView, Badge, createResource, Dropdown } from "frappe-ui";
 import { formatDateTime } from "@/utils/date";
 import Avatar from "@/components/ui/Avatar.vue";
 import Drawer from "@/components/ui/Drawer.vue";
@@ -64,8 +65,38 @@ const columns = computed(() => [
         width: 1,
     },
 ]);
+
+const onExport = (fileType: "CSV" | "Excel") => {
+    const params = new URLSearchParams({
+        form_id: manageFormStore.currentFormId ?? "",
+        file_type: fileType,
+    });
+    window.location.href = `/api/method/forms_pro.api.export.export_submissions?${params}`;
+};
+
+const dropdownItems = computed(() => [
+    {
+        label: "Export as CSV",
+        icon: FileText,
+        onClick: () => onExport("CSV"),
+    },
+    {
+        label: "Export as Excel",
+        icon: Sheet,
+        onClick: () => onExport("Excel"),
+    },
+]);
 </script>
 <template>
+    <div>
+        <Dropdown
+            :button="{
+                label: 'Export',
+                iconLeft: Download,
+            }"
+            :options="dropdownItems"
+        />
+    </div>
     <ListView
         :columns="columns"
         :rows="allSubmissions"

--- a/frontend/src/components/form/submissions/SubmissionList.vue
+++ b/frontend/src/components/form/submissions/SubmissionList.vue
@@ -67,10 +67,12 @@ const columns = computed(() => [
 ]);
 
 const onExport = (fileType: "CSV" | "Excel") => {
-    const params = new URLSearchParams({
-        form_id: manageFormStore.currentFormId ?? "",
-        file_type: fileType,
-    });
+    const formId = manageFormStore.currentFormId;
+    if (!formId) {
+        toast.error("Unable to export", { description: "No form selected." });
+        return;
+    }
+    const params = new URLSearchParams({ form_id: formId, file_type: fileType });
     window.location.href = `/api/method/forms_pro.api.export.export_submissions?${params}`;
 };
 


### PR DESCRIPTION
## Summary

Adds a per-form **Export** action that downloads submissions as CSV or Excel. The exporter is gated on `Form.write` (Forms Pro permissions live on the Form, not on the linked DocType) and reuses Frappe's built-in `DataExporter` under a scoped privilege swap.

## Backend (`forms_pro/api/export.py`)

- New whitelisted method `export_submissions(form_id, file_type)`.
- `file_type: Literal[\"CSV\", \"Excel\"]`, validated at runtime (the static `Literal` is not enforced over HTTP).
- Authorization: `frappe.has_permission(\"Form\", \"write\", form_id)`.
- DataExporter enforces `can_export` on the **linked DocType**, which Forms Pro does not grant at the role level. To bridge that gap the exporter runs as Administrator inside a `try/finally`. `user`, `sid` and `session.data` are snapshotted before the swap and restored afterward; without restoring `sid` and `data` the response cookie is broken and the user is silently logged out on the next request.
- Submissions are scoped by `fp_linked_form` so a Form does not leak rows of other Forms sharing the same linked DocType.
- Display-only fields (Heading 1/2/3, etc.) are excluded via a new `FormField.stores_value` property derived from `frappe.model.no_value_fields`.
- Download filename uses `werkzeug.utils.secure_filename(form.title)` plus a timestamp; falls back to `form_id` if the title sanitizes to empty.
- `make_access_log` is recorded under the real user (before the swap) so audit attribution is correct.

## Frontend (`SubmissionList.vue`)

- New **Export** dropdown with **CSV** and **Excel** options.
- Triggers a real browser navigation (`window.location.href`) so Frappe sends `Content-Disposition: attachment` and the file actually downloads. An XHR via `createResource` returns the body as JSON-ish text and never triggers a download.

## Tests (`forms_pro/tests/test_export.py`)

10 integration tests, 6 classes:

| Class | Covers |
|---|---|
| `TestExportFileType` | `Excel` reaches xlsx branch (not CSV); unsupported `file_type` raises `ValidationError`. |
| `TestExportScopedByForm` | Two forms on same linked DocType; export of form A excludes form B's rows and values. |
| `TestExportFieldSelection` | Display-only fields absent; all exportable fields present in CSV header. |
| `TestExportPermissions` | User without DocShare on the form is rejected with `PermissionError`. |
| `TestExportAccessLog` | Exactly one Access Log row written per call, attributed to caller (not `Administrator`). |
| `TestExportSessionRestoration` | `frappe.session.user` restored after success and when `DataExporter` raises. |

Two new factories under `forms_pro/tests/factories/`:

- `LinkedFormDoctypeFactory` - placeholder custom DocType pre-wired with `fp_submission_status` and `fp_linked_form`.
- `FormFactory` - standard `frappe_factory_bot` pattern; defaults honor `self.overrides.get(...)` for `linked_doctype` and `linked_team_id` to avoid orphaning related records.

## Verification

\`\`\`
bench --site forms.dev run-tests --app forms_pro
Ran 61 tests in ~12s
OK (skipped=2)
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Form submissions can now be exported in CSV or Excel format using a new dropdown menu in the submissions interface, providing flexible options for data extraction and analysis.

* **Tests**
  * Comprehensive test coverage added for export functionality, validating file format handling, user permissions, and submission data accuracy.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BuildWithHussain/forms_pro/pull/133)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->