### PR TITLE
fix: icon route from '/forms_pro' to '/forms'

### DIFF
--- a/forms_pro/hooks.py
+++ b/forms_pro/hooks.py
@@ -15,7 +15,7 @@ add_to_apps_screen = [
         "name": "forms_pro",
         "logo": "/assets/forms_pro/images/logo_300.png",
         "title": "Forms Pro",
-        "route": "/forms_pro",
+        "route": "/forms",
         "has_permission": "forms_pro.overrides.roles.has_forms_pro_permission",
     }
 ]


### PR DESCRIPTION
## Summary

- Describe the change and the reason for it.

## Testing

- [ ] `pre-commit run --all-files`
- [ ] `cd frontend && yarn typecheck`
- [ ] `bench --site <site> run-tests --app forms_pro`

## Checklist

- [ ] PR title follows the conventional format used by this repo
- [ ] Documentation updated if behavior or setup changed
- [ ] Screenshots attached for UI changes when useful


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the app’s navigation link so it now opens the forms area at the correct address.
  * This helps users reach the forms section more consistently from the apps screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->